### PR TITLE
Fix: Add missing cache handling for matrix job

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -15,21 +15,21 @@ inputs:
   permit_fail:
     description: 'Continue/pass even when the audit fails'
     required: false
-    type: boolean
-    default: false
+    # type: boolean
+    default: 'false'
   artefact_path:
     description: 'Path/location to build artefacts'
-    type: string
+    # type: string
     required: false
     default: 'dist'
   summary:
     description: 'Whether to generate summary output'
-    type: boolean
+    # type: boolean
     required: false
-    default: true
+    default: 'true'
   path_prefix:
     description: 'Directory location containing project code'
-    type: string
+    # type: string
     required: false
     default: ''
 
@@ -55,6 +55,24 @@ runs:
       uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: "${{ inputs.python_version }}"
+
+    - name: 'Cache Python dependencies'
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.0.2
+      with:
+        path: |
+          ~/.cache/pip
+          ~/.cache/pypoetry
+          ~/.cache/pipenv
+          .venv
+          .tox
+        # yamllint disable rule:line-length
+        key: >-
+          python-${{ runner.os }}-${{ inputs.python_version }}-
+          ${{ hashFiles('**/requirements*.txt', '**/pyproject.toml', '**/poetry.lock', '**/Pipfile*', '**/setup.py', '**/setup.cfg') }}
+        restore-keys: |
+          python-${{ runner.os }}-${{ inputs.python_version }}-
+          python-${{ runner.os }}-
+        # yamllint enable rule:line-length
 
     - name: 'Install build products/dependencies'
       shell: bash


### PR DESCRIPTION
Matrix jobs must use relevant cache keys and restore-keys for the Python version they run to prevent pulling invalid cache content.

Also addresses JSON schema violations for input/types and quotes strings correctly.