### PR TITLE
Chore: Bump python-project-name-action to v0.1.6

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -50,7 +50,7 @@ runs:
     - name: 'Extract Python project naming/metadata'
       id: naming
       # yamllint disable-line rule:line-length
-      uses: lfreleng-actions/python-project-name-action@a8287d8627a34a40aacc33f73348dfb0b47b6cea # v0.1.5
+      uses: lfreleng-actions/python-project-name-action@9f2cc7d37847d5f5497ba87d14e574b2f0a07462 # v0.1.6
       with:
         path_prefix: "${{ inputs.path_prefix }}"
 


### PR DESCRIPTION
## Summary

Bumps the `python-project-name-action` pin from
`a8287d8627a34a40aacc33f73348dfb0b47b6cea` (v0.1.5) to the upstream
release commit
`9f2cc7d37847d5f5497ba87d14e574b2f0a07462` (**v0.1.6**).

## Motivation

`python-project-name-action` v0.1.5 only extracts project names from
`pyproject.toml` and `setup.py`. Legacy / pbr-style projects keep their
name in `setup.cfg [metadata] name`, which v0.1.5 did not support. As
a result `python-audit-action` failed on such projects — for example,
the [lfit/releng-docs-conf Gerrit Verify build](https://github.com/lfit/releng-docs-conf/actions/runs/25217124950).

[python-project-name-action#98](https://github.com/lfreleng-actions/python-project-name-action/pull/98)
added the `setup.cfg` extraction path; v0.1.6 contains it. This PR
wires the new release through so `python-audit-action` correctly
identifies the project name on legacy layouts.

## Diff

```diff
-      uses: lfreleng-actions/python-project-name-action@a8287d8627a34a40aacc33f73348dfb0b47b6cea # v0.1.5
+      uses: lfreleng-actions/python-project-name-action@9f2cc7d37847d5f5497ba87d14e574b2f0a07462 # v0.1.6
```

## History

Earlier patchsets of this PR temporarily pinned to a commit on a fork
branch (`modeseven-lfreleng-actions/python-project-name-action`, PR #98
HEAD) so the chain could be validated end-to-end against `docs-conf`
before the upstream release existed. Now that PR #98 has merged and
v0.1.6 has been cut, this PR pins directly to the upstream release
commit SHA per the [GitHub Action Calls pinning convention](#).

## Refs

- Upstream dependency: https://github.com/lfreleng-actions/python-project-name-action/pull/98 (merged)
- Release: `lfreleng-actions/python-project-name-action@v0.1.6`
- Failing run that motivated the chain of changes: https://github.com/lfit/releng-docs-conf/actions/runs/25217124950
