### PR TITLE
Feat: Support central vulnerability allow-list file

### DIFF
--- a/.github/workflows/resolver-tests.yaml
+++ b/.github/workflows/resolver-tests.yaml
@@ -1,0 +1,68 @@
+---
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+# Runs the shared config-resolver unit tests (pytest).
+#
+# The action's main code path is exercised via node (see
+# testing.yaml), but the shared src/resolve_config_source.py module
+# carries its own pytest suite that pins the `config` grammar and the
+# mode-selected sanitisers. Without this job those tests would never
+# run in CI and regressions could merge unnoticed.
+
+name: 'Resolver tests 🧪'
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_dispatch:
+  push:
+    branches: ['main']
+    paths:
+      - 'src/resolve_config_source.py'
+      - 'tests/test_resolve_config_source.py'
+      - '.github/workflows/resolver-tests.yaml'
+  pull_request:
+    branches: ['main']
+    paths:
+      - 'src/resolve_config_source.py'
+      - 'tests/test_resolve_config_source.py'
+      - '.github/workflows/resolver-tests.yaml'
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  pytest:
+    name: 'Run resolver unit tests'
+    runs-on: 'ubuntu-24.04'
+    permissions:
+      contents: read
+    timeout-minutes: 5
+    steps:
+      - name: 'Harden runner'
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        with:
+          egress-policy: audit
+
+      - name: 'Checkout repository'
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: 'Setup Python'
+        # yamllint disable-line rule:line-length
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: '3.13'
+
+      - name: 'Run resolver unit tests'
+        shell: bash
+        run: |
+          # Stdlib-only module; pytest is the sole test dependency.
+          python -m pip install --disable-pip-version-check -q pytest
+          python -m pytest tests/test_resolve_config_source.py -q

--- a/.github/workflows/sync-shared-resolver.yaml
+++ b/.github/workflows/sync-shared-resolver.yaml
@@ -1,0 +1,94 @@
+---
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+# Verifies the shared config resolver stays byte-identical with the
+# sibling repository.
+#
+# src/resolve_config_source.py and tests/test_resolve_config_source.py
+# are mirrored, byte-for-byte, across:
+#   - lfreleng-actions/harden-runner-block-action
+#   - lfreleng-actions/python-audit-action
+#
+# This job compares this repository's copies against the sibling repo's
+# default branch and fails on any drift. It runs after merge (push to
+# main), on a weekly schedule, and on demand — deliberately NOT as a
+# required pull-request check, so a coordinated pair of PRs (which
+# briefly makes the two default branches differ until the second one
+# merges) does not deadlock. A red main after the first merge is the
+# intended signal to land the paired PR in the sibling repo.
+
+name: 'Sync shared resolver 🔁'
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'
+  push:
+    branches: ['main']
+    paths:
+      - 'src/resolve_config_source.py'
+      - 'tests/test_resolve_config_source.py'
+      - '.github/workflows/sync-shared-resolver.yaml'
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  verify-sync:
+    name: 'Verify shared resolver matches sibling repo'
+    runs-on: 'ubuntu-24.04'
+    permissions:
+      contents: read
+    timeout-minutes: 5
+    env:
+      # The sibling repository that mirrors the shared resolver.
+      SIBLING_REPO: 'lfreleng-actions/harden-runner-block-action'
+    steps:
+      - name: 'Harden runner'
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        with:
+          egress-policy: audit
+
+      - name: 'Checkout repository'
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: "Diff shared files against ${{ env.SIBLING_REPO }}"
+        shell: bash
+        run: |
+          # Compare each shared file against the sibling repo's default
+          # branch (HEAD). Any difference fails the job.
+          set -euo pipefail
+          fail=0
+          files=(
+            'src/resolve_config_source.py'
+            'tests/test_resolve_config_source.py'
+          )
+          for f in "${files[@]}"; do
+            url="https://raw.githubusercontent.com/${SIBLING_REPO}/HEAD/${f}"
+            echo "Fetching ${url}"
+            if ! curl --proto '=https' --tlsv1.2 \
+              -sSfL --max-time 30 -o sibling.tmp "$url"; then
+              echo "::error::Could not fetch ${f} from ${SIBLING_REPO}"
+              fail=1
+              continue
+            fi
+            if diff -u "$f" sibling.tmp; then
+              echo "${f} matches ${SIBLING_REPO} ✅"
+            else
+              echo "::error::${f} differs from ${SIBLING_REPO};" \
+                   "the shared resolver must stay byte-identical." \
+                   "Raise paired PRs in both repositories."
+              fail=1
+            fi
+            rm -f sibling.tmp
+          done
+          exit "$fail"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,15 +53,18 @@ repos:
     rev: 0c7b6c989466a93942def1f84baf36ddfcd60c83  # frozen: v0.15.14
     hooks:
       - id: ruff
-        files: ^(scripts|tests|custom_components)/.+\.py$
+        files: ^(src|scripts|tests|custom_components)/.+\.py$
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
-        files: ^(scripts|tests|custom_components)/.+\.py$
+        files: ^(src|scripts|tests|custom_components)/.+\.py$
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: d2823d321df3af8f878f7ee3414dc94d037145b9  # frozen: v2.1.0
     hooks:
       - id: mypy
+        # The resolver test module imports pytest; make it available in
+        # the hook's isolated environment so mypy can resolve the import.
+        additional_dependencies: ["pytest"]
 
   - repo: https://github.com/btford/write-good
     rev: ab66ce10136dfad5146e69e70f82a3efac8842c1 # frozen: v1.0.8

--- a/README.md
+++ b/README.md
@@ -314,6 +314,24 @@ commit supplied the allow-list.
 > pull requests across `python-audit-action` and
 > `harden-runner-block-action`.
 
+#### Suppressing the step summary on matrix jobs
+
+Each matrix leg is a separate job with its own step summary, so the
+allow-list block repeats once per leg. An action cannot detect the
+matrix context itself, but the calling workflow can. Set
+`allow_list_summary` so a single leg emits the block:
+
+```yaml
+        with:
+          python_version: ${{ matrix.python-version }}
+          # Emit the allow-list summary from the first matrix leg.
+          allow_list_summary: ${{ strategy.job-index == 0 }}
+```
+
+Outside a matrix, `strategy.job-index` is empty; use
+`${{ !strategy.job-total || strategy.job-index == 0 }}` if a single
+template must cover both matrix and non-matrix jobs.
+
 ## Inputs
 
 <!-- markdownlint-disable MD013 -->
@@ -333,6 +351,7 @@ commit supplied the allow-list.
 | allow_list_disable | False    | False     | Skip allow-list loading entirely.                                                                                                                            |
 | config             | False    | ""        | `uses:`-style coordinate for a git-fetched, SHA-pinnable allow-list. Mutually exclusive with the `allow_list_*` inputs. See above.                           |
 | token              | False    | ""        | Token with `contents:read` for fetching a private host repo via `config`. Leave empty for public repos.                                                      |
+| allow_list_summary | False    | True      | Write the allow-list/config block to the job step summary. Set `false` to suppress (e.g. on matrix legs other than the first). See note below.               |
 
 <!-- markdownlint-enable MD013 -->
 

--- a/README.md
+++ b/README.md
@@ -197,6 +197,123 @@ GHSA-4xh5-x5gv-qwph
 PYSEC-2025-183
 ```
 
+### Pinned allow-list via `config` (git, SHA-pinnable)
+
+The `config` input is a GitHub-Actions `uses:`-style coordinate that
+identifies a remote allow-list file and fetches it with a shallow,
+ref-pinned **git** fetch (rather than an unpinned HTTP download). It
+supports branches, tags and commit SHAs, so you can pin the
+allow-list to an immutable commit, much like an action pin.
+
+> [!IMPORTANT]
+> `config` is **mutually exclusive** with the `allow_list_*` inputs.
+> Supplying any of `allow_list_path`, `allow_list_url`,
+> `allow_list_org` or `allow_list_disable` together with `config` is
+> an error. The `ignore_vulns` input is *not* a source and still
+> merges with the IDs loaded via `config`.
+
+```yaml
+      - name: "Audit project dependencies"
+        uses: lfreleng-actions/python-audit-action@main
+        with:
+          python_version: ${{ matrix.python-version }}
+          config: "lfreleng-actions@v1.0.0"
+```
+
+#### `config` grammar
+
+```text
+<config> ::= <source> [ "@" <ref> ] [ <ws>+ "#" <comment> ]
+<source> ::= [ <host-org> [ "/" <repo> ] ] [ "//" <subpath> ]
+```
+
+Defaults applied to anything you omit:
+
+<!-- markdownlint-disable MD013 -->
+
+| Element   | Default                                                             |
+| --------- | ------------------------------------------------------------------- |
+| host-org  | `github.repository_owner` (when you omit the org)                   |
+| repo      | `.github`                                                           |
+| directory | `.github/python-audit/<workflow-org>/` then `.github/python-audit/` |
+| filename  | `allow_list.txt`                                                    |
+| ref       | the host repo's default branch (`HEAD`)                             |
+
+<!-- markdownlint-enable MD013 -->
+
+- The `//` separator splits the repository from the in-repo path
+  (the same convention Terraform/go-getter use). Text after `//`:
+  - **empty** (or no `//`) — default directory search + default
+    filename.
+  - **bare filename** (no `/`) — overrides the filename, keeps the
+    default directory search.
+  - **contains a `/`** — an explicit in-repo path; the action skips
+    the search and that exact path must exist.
+- One or more spaces then `#` starts a trailing comment, which the
+  parser drops (`#`, `#`, `\t#` all work).
+- The output `resolved_sha` always reports the commit the ref
+  resolved to, even when you pin a branch or tag.
+
+#### Search / fallback chain
+
+When the directory is auto-derived (you did not give an explicit
+directory after `//`), the action tries, in order:
+
+1. `.github/python-audit/<workflow-org>/<filename>` (org-specific)
+2. `.github/python-audit/<filename>` (host-wide family default)
+
+The first file that exists wins. If neither exists, the action
+proceeds with `ignore_vulns` alone (soft, no warning) — consistent
+with the default-URL behaviour above. An **explicit** path that is
+missing is always a hard error.
+
+#### `config` examples
+
+Assuming the workflow runs in org `onap`:
+
+<!-- markdownlint-disable MD013 -->
+
+| `config` value                         | Fetched from                    | In-repo path (search chain)                                              |
+| -------------------------------------- | ------------------------------- | ------------------------------------------------------------------------ |
+| `lfreleng-actions@main`                | `lfreleng-actions/.github@main` | `…/python-audit/onap/allow_list.txt` → `…/python-audit/allow_list.txt`   |
+| `lfit@v1.1.0`                          | `lfit/.github@v1.1.0`           | same chain                                                               |
+| `lfit@ab7a940… # v1.0.0`               | `lfit/.github@<sha>`            | same chain; comment ignored                                              |
+| `lfit//custom_list.txt@v1.1.0  # ONAP` | `lfit/.github@v1.1.0`           | `…/python-audit/onap/custom_list.txt` → `…/python-audit/custom_list.txt` |
+| `lfit//@ab7a940…`                      | `lfit/.github@<sha>`            | default chain + `allow_list.txt`                                         |
+| `lfit//configs/onap/list.txt@main`     | `lfit/.github@main`             | `configs/onap/list.txt` (explicit; no search)                            |
+| `//team_list.txt@main`                 | `onap/.github@main`             | `…/python-audit/onap/team_list.txt` → `…/python-audit/team_list.txt`     |
+
+<!-- markdownlint-enable MD013 -->
+
+#### Private host repositories
+
+For a private host-org `.github` repo, pass a token with
+`contents:read` on that repo. `GITHUB_TOKEN` grants access to the
+current repository alone, so pass a PAT or GitHub App token here:
+
+```yaml
+        with:
+          python_version: ${{ matrix.python-version }}
+          config: "my-private-org@v2.0.0"
+          token: ${{ secrets.CONFIG_READ_TOKEN }}
+```
+
+#### `config` outputs
+
+Using `config` makes the action expose: `resolved_host_org`,
+`resolved_repo`, `resolved_ref`, `resolved_sha`, `resolved_path` and
+`matched_candidate`. Use `resolved_sha` to record or assert which
+commit supplied the allow-list.
+
+> [!NOTE]
+> `config` resolution uses the runner's preinstalled `python3` (the
+> resolver needs no third-party packages). GitHub-hosted runners
+> ship it; on self-hosted runners `python3` must sit on `PATH`. Both
+> repositories mirror the shared parser
+> `src/resolve_config_source.py`, and changes must land as paired
+> pull requests across `python-audit-action` and
+> `harden-runner-block-action`.
+
 ## Inputs
 
 <!-- markdownlint-disable MD013 -->
@@ -214,6 +331,8 @@ PYSEC-2025-183
 | allow_list_url     | False    |           | Explicit HTTPS URL to fetch the allow-list from. The action ignores this when `allow_list_path` has a value.                                                 |
 | allow_list_org     | False    |           | Org used to construct the default allow-list URL. Defaults to `github.repository_owner`.                                                                     |
 | allow_list_disable | False    | False     | Skip allow-list loading entirely.                                                                                                                            |
+| config             | False    | ""        | `uses:`-style coordinate for a git-fetched, SHA-pinnable allow-list. Mutually exclusive with the `allow_list_*` inputs. See above.                           |
+| token              | False    | ""        | Token with `contents:read` for fetching a private host repo via `config`. Leave empty for public repos.                                                      |
 
 <!-- markdownlint-enable MD013 -->
 

--- a/README.md
+++ b/README.md
@@ -95,8 +95,17 @@ To audit all vulnerabilities and bypass default exclusions:
         uses: lfreleng-actions/python-audit-action@main
         with:
           python_version: ${{ matrix.python-version }}
-          ignore_vulns: ""  # Empty string clears defaults
+          ignore_vulns: ""            # Clears the ignore_vulns default
+          allow_list_disable: "true"  # Also skip the central allow-list
 ```
+
+> [!IMPORTANT]
+> An empty `ignore_vulns` resets that one input's default, but the
+> action still loads the central allow-list automatically (see below).
+> To audit **every** vulnerability, also set
+> `allow_list_disable: "true"` and do not pass `config` (`config` is
+> another allow-list source and is mutually exclusive with
+> `allow_list_disable`).
 
 ### Ignoring Specific Vulnerabilities
 
@@ -178,7 +187,7 @@ must match one of:
 - `GHSA-xxxx-xxxx-xxxx` (lowercase alphanumerics)
 - `PYSEC-YYYY-N+`
 - `OSV-YYYY-N+`
-- `PVE-N+`
+- `PVE-N+` or `PVE-N+-N+` (e.g. `PVE-2021-99`)
 
 Any token that does not match one of these patterns fails the step
 rather than passing through unrecognised.
@@ -206,11 +215,11 @@ supports branches, tags and commit SHAs, so you can pin the
 allow-list to an immutable commit, much like an action pin.
 
 > [!IMPORTANT]
-> `config` is **mutually exclusive** with the `allow_list_*` inputs.
-> Supplying any of `allow_list_path`, `allow_list_url`,
+> `config` is **mutually exclusive** with the allow-list *source*
+> inputs: supplying any of `allow_list_path`, `allow_list_url`,
 > `allow_list_org` or `allow_list_disable` together with `config` is
-> an error. The `ignore_vulns` input is *not* a source and still
-> merges with the IDs loaded via `config`.
+> an error. (`allow_list_summary` still applies, and `ignore_vulns`
+> is not a source and still merges with the IDs loaded via `config`.)
 
 ```yaml
       - name: "Audit project dependencies"
@@ -249,8 +258,10 @@ Defaults applied to anything you omit:
     default directory search.
   - **contains a `/`** — an explicit in-repo path; the action skips
     the search and that exact path must exist.
-- One or more spaces then `#` starts a trailing comment, which the
-  parser drops (`#`, `#`, `\t#` all work).
+- A `#` preceded by at least one space or tab starts a trailing
+  comment; the parser drops everything from that `#` to end of line.
+  A `#` with no preceding whitespace forms part of a token
+  (so `foo#bar` is a single token, not a comment).
 - The output `resolved_sha` always reports the commit the ref
   resolved to, even when you pin a branch or tag.
 
@@ -307,11 +318,11 @@ commit supplied the allow-list.
 
 > [!NOTE]
 > `config` resolution uses the runner's preinstalled `python3` (the
-> resolver needs no third-party packages). GitHub-hosted runners
-> ship it; on self-hosted runners `python3` must sit on `PATH`. Both
-> repositories mirror the shared parser
-> `src/resolve_config_source.py`, and changes must land as paired
-> pull requests across `python-audit-action` and
+> resolver needs no third-party packages) and shells out to `git` for
+> the fetch. GitHub-hosted runners ship both; on self-hosted runners
+> `python3` and `git` must sit on `PATH`. Both repositories mirror the
+> shared parser `src/resolve_config_source.py`, and changes must land
+> as paired pull requests across `python-audit-action` and
 > `harden-runner-block-action`.
 
 #### Suppressing the step summary on matrix jobs
@@ -336,22 +347,22 @@ template must cover both matrix and non-matrix jobs.
 
 <!-- markdownlint-disable MD013 -->
 
-| Variable Name      | Required | Default   | Description                                                                                                                                                  |
-| ------------------ | -------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| python_version     | True     | N/A       | Matrix job Python version                                                                                                                                    |
-| artefact_name      | False    |           | Custom name for downloaded artefacts (defaults to project name). Useful when building for different platforms/architectures to avoid artefact name conflicts |
-| permit_fail        | False    | False     | Continue/pass even when the audit fails                                                                                                                      |
-| artefact_path      | False    | "dist"    | Path/location to build artefacts                                                                                                                             |
-| summary            | False    | True      | Whether pypa/gh-action-pip-audit generates summary output                                                                                                    |
-| path_prefix        | False    | ""        | Path/directory to Python project code                                                                                                                        |
-| ignore_vulns       | False    | See below | Vulnerability IDs to ignore (whitespace separated). Merged with allow-list IDs.                                                                              |
-| allow_list_path    | False    |           | Local path to allow-list file. Highest precedence; overrides URL and org.                                                                                    |
-| allow_list_url     | False    |           | Explicit HTTPS URL to fetch the allow-list from. The action ignores this when `allow_list_path` has a value.                                                 |
-| allow_list_org     | False    |           | Org used to construct the default allow-list URL. Defaults to `github.repository_owner`.                                                                     |
-| allow_list_disable | False    | False     | Skip allow-list loading entirely.                                                                                                                            |
-| config             | False    | ""        | `uses:`-style coordinate for a git-fetched, SHA-pinnable allow-list. Mutually exclusive with the `allow_list_*` inputs. See above.                           |
-| token              | False    | ""        | Token with `contents:read` for fetching a private host repo via `config`. Leave empty for public repos.                                                      |
-| allow_list_summary | False    | True      | Write the allow-list/config block to the job step summary. Set `false` to suppress (e.g. on matrix legs other than the first). See note below.               |
+| Variable Name      | Required | Default   | Description                                                                                                                                                                                                                |
+| ------------------ | -------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| python_version     | True     | N/A       | Matrix job Python version                                                                                                                                                                                                  |
+| artefact_name      | False    |           | Custom name for downloaded artefacts (defaults to project name). Useful when building for different platforms/architectures to avoid artefact name conflicts                                                               |
+| permit_fail        | False    | False     | Continue/pass even when the audit fails                                                                                                                                                                                    |
+| artefact_path      | False    | "dist"    | Path/location to build artefacts                                                                                                                                                                                           |
+| summary            | False    | True      | Whether pypa/gh-action-pip-audit generates summary output                                                                                                                                                                  |
+| path_prefix        | False    | ""        | Path/directory to Python project code                                                                                                                                                                                      |
+| ignore_vulns       | False    | See below | Vulnerability IDs to ignore (whitespace separated). Merged with allow-list IDs.                                                                                                                                            |
+| allow_list_path    | False    |           | Local path to allow-list file. Highest precedence; overrides URL and org.                                                                                                                                                  |
+| allow_list_url     | False    |           | Explicit HTTPS URL to fetch the allow-list from. The action ignores this when `allow_list_path` has a value.                                                                                                               |
+| allow_list_org     | False    |           | Org used to construct the default allow-list URL. Defaults to `github.repository_owner`.                                                                                                                                   |
+| allow_list_disable | False    | False     | Skip allow-list loading entirely.                                                                                                                                                                                          |
+| config             | False    | ""        | `uses:`-style coordinate for a git-fetched, SHA-pinnable allow-list. Mutually exclusive with `allow_list_path`/`allow_list_url`/`allow_list_org`/`allow_list_disable` (but `allow_list_summary` still applies). See above. |
+| token              | False    | ""        | Token with `contents:read` for fetching a private host repo via `config`. Leave empty for public repos.                                                                                                                    |
+| allow_list_summary | False    | True      | Write the allow-list/config block to the job step summary. Set `false` to suppress (e.g. on matrix legs other than the first). See note below.                                                                             |
 
 <!-- markdownlint-enable MD013 -->
 

--- a/README.md
+++ b/README.md
@@ -110,19 +110,110 @@ To ignore specific vulnerabilities:
           ignore_vulns: "GHSA-4xh5-x5gv-qwph CVE-2024-XXXX-YYYY"
 ```
 
+### Centrally managed allow-list (recommended)
+
+The action can load a vulnerability allow-list from a file hosted in
+the organisation's `.github` repository. With no `allow_list_*`
+inputs supplied, the action attempts to fetch:
+
+```text
+https://raw.githubusercontent.com/<org>/.github/HEAD/.github/python-audit/<org>/allow_list.txt
+```
+
+where `<org>` defaults to `github.repository_owner`. IDs from this
+file merge with whatever the caller passes in `ignore_vulns` (with
+duplicates removed).
+
+This behaviour is automatic: when the default URL returns a 404
+(no central file published) the action proceeds with the
+`ignore_vulns` input alone, without emitting a warning. An
+explicitly-supplied `allow_list_path` or `allow_list_url` that
+fails to load is a hard error.
+
+```yaml
+      - name: "Audit project dependencies"
+        uses: lfreleng-actions/python-audit-action@main
+        with:
+          python_version: ${{ matrix.python-version }}
+          # No allow_list_* inputs: defaults to the org's .github file.
+```
+
+To load from a local file (highest precedence; overrides URL and org):
+
+```yaml
+      - name: "Audit project dependencies"
+        uses: lfreleng-actions/python-audit-action@main
+        with:
+          python_version: ${{ matrix.python-version }}
+          allow_list_path: ".github/python-audit/${{ github.repository_owner }}/allow_list.txt"
+```
+
+To load from an explicit URL:
+
+```yaml
+      - name: "Audit project dependencies"
+        uses: lfreleng-actions/python-audit-action@main
+        with:
+          python_version: ${{ matrix.python-version }}
+          allow_list_url: "https://example.com/python-audit-allow-list.txt"
+```
+
+To opt out of allow-list loading entirely:
+
+```yaml
+      - name: "Audit project dependencies"
+        uses: lfreleng-actions/python-audit-action@main
+        with:
+          python_version: ${{ matrix.python-version }}
+          allow_list_disable: "true"
+```
+
+#### Allow-list file format
+
+Whitespace-separated vulnerability IDs. `#` introduces a comment
+(full-line or trailing). The parser skips blank lines. Each token
+must match one of:
+
+- `CVE-YYYY-NNNN[N...]`
+- `GHSA-xxxx-xxxx-xxxx` (lowercase alphanumerics)
+- `PYSEC-YYYY-N+`
+- `OSV-YYYY-N+`
+- `PVE-N+`
+
+Any token that does not match one of these patterns fails the step
+rather than passing through unrecognised.
+
+Example file (e.g.
+`.github/python-audit/lfreleng-actions/allow_list.txt`):
+
+```text
+# lfreleng-actions: globally allow-listed Python audit vulnerabilities
+
+# pip: malicious sdist link traversal (no fix in shipped pip versions)
+GHSA-4xh5-x5gv-qwph
+
+# pyjwt: disputed by upstream; key length is the application's
+# responsibility, not the library's.
+PYSEC-2025-183
+```
+
 ## Inputs
 
 <!-- markdownlint-disable MD013 -->
 
-| Variable Name  | Required | Default   | Description                                                                                                                                                  |
-| -------------- | -------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| python_version | True     | N/A       | Matrix job Python version                                                                                                                                    |
-| artefact_name  | False    |           | Custom name for downloaded artefacts (defaults to project name). Useful when building for different platforms/architectures to avoid artefact name conflicts |
-| permit_fail    | False    | False     | Continue/pass even when the audit fails                                                                                                                      |
-| artefact_path  | False    | "dist"    | Path/location to build artefacts                                                                                                                             |
-| summary        | False    | True      | Whether pypa/gh-action-pip-audit generates summary output                                                                                                    |
-| path_prefix    | False    | ""        | Path/directory to Python project code                                                                                                                        |
-| ignore_vulns   | False    | See below | Vulnerability IDs to ignore (whitespace separated)                                                                                                           |
+| Variable Name      | Required | Default   | Description                                                                                                                                                  |
+| ------------------ | -------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| python_version     | True     | N/A       | Matrix job Python version                                                                                                                                    |
+| artefact_name      | False    |           | Custom name for downloaded artefacts (defaults to project name). Useful when building for different platforms/architectures to avoid artefact name conflicts |
+| permit_fail        | False    | False     | Continue/pass even when the audit fails                                                                                                                      |
+| artefact_path      | False    | "dist"    | Path/location to build artefacts                                                                                                                             |
+| summary            | False    | True      | Whether pypa/gh-action-pip-audit generates summary output                                                                                                    |
+| path_prefix        | False    | ""        | Path/directory to Python project code                                                                                                                        |
+| ignore_vulns       | False    | See below | Vulnerability IDs to ignore (whitespace separated). Merged with allow-list IDs.                                                                              |
+| allow_list_path    | False    |           | Local path to allow-list file. Highest precedence; overrides URL and org.                                                                                    |
+| allow_list_url     | False    |           | Explicit HTTPS URL to fetch the allow-list from. The action ignores this when `allow_list_path` has a value.                                                 |
+| allow_list_org     | False    |           | Org used to construct the default allow-list URL. Defaults to `github.repository_owner`.                                                                     |
+| allow_list_disable | False    | False     | Skip allow-list loading entirely.                                                                                                                            |
 
 <!-- markdownlint-enable MD013 -->
 

--- a/action.yaml
+++ b/action.yaml
@@ -103,6 +103,16 @@ inputs:
     # type: string
     required: false
     default: ''
+  allow_list_summary:
+    description: >
+      Whether to write the allow-list/config block to the job step
+      summary. Set to 'false' to suppress it. Useful for matrix jobs,
+      where the same block would otherwise repeat once per leg; emit
+      it on a single leg with, e.g.,
+      allow_list_summary: ${{ strategy.job-index == 0 }}.
+    # type: boolean
+    required: false
+    default: 'true'
 
 outputs:
   resolved_host_org:
@@ -197,6 +207,7 @@ runs:
         AL_URL: "${{ inputs.allow_list_url }}"
         AL_ORG: "${{ inputs.allow_list_org }}"
         AL_DISABLE: "${{ inputs.allow_list_disable }}"
+        ALLOW_LIST_SUMMARY: "${{ inputs.allow_list_summary }}"
         ACTION_PATH: "${{ github.action_path }}"
       run: |
         # Resolve allow-list via the 'config' uses-style coordinate.
@@ -227,6 +238,13 @@ runs:
         # file at an auto-derived path exits 0 with empty ids (soft);
         # an explicitly-named missing file or any validation/network
         # failure exits non-zero and fails this step.
+        #
+        # An empty --step-summary target suppresses the summary block
+        # (e.g. matrix legs other than the first).
+        summary_target="$GITHUB_STEP_SUMMARY"
+        if [ "$ALLOW_LIST_SUMMARY" = "false" ]; then
+          summary_target=""
+        fi
         python3 "${ACTION_PATH}/src/resolve_config_source.py" \
           --config "$CONFIG" \
           --workflow-org "$REPO_OWNER" \
@@ -237,7 +255,7 @@ runs:
           --summary-title "🐍 Python audit allow-list" \
           --summary-unit Entries \
           --github-output "$GITHUB_OUTPUT" \
-          --step-summary "$GITHUB_STEP_SUMMARY"
+          --step-summary "$summary_target"
 
     - name: 'Resolve vulnerability allow-list'
       id: allow_list
@@ -248,6 +266,7 @@ runs:
         ALLOW_LIST_URL: "${{ inputs.allow_list_url }}"
         ALLOW_LIST_ORG: "${{ inputs.allow_list_org }}"
         ALLOW_LIST_DISABLE: "${{ inputs.allow_list_disable }}"
+        ALLOW_LIST_SUMMARY: "${{ inputs.allow_list_summary }}"
         REPO_OWNER: "${{ github.repository_owner }}"
       run: |
         # Resolve vulnerability allow-list
@@ -279,6 +298,9 @@ runs:
         }
 
         summary_line() {
+          if [ "$ALLOW_LIST_SUMMARY" = "false" ]; then
+            return 0
+          fi
           if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
             printf '%s\n' "$1" >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/action.yaml
+++ b/action.yaml
@@ -39,10 +39,50 @@ inputs:
     required: false
     default: ''
   ignore_vulns:
-    description: 'Vulnerability IDs to ignore (whitespace separated)'
+    description: >
+      Vulnerability IDs to ignore (whitespace separated). These IDs
+      are merged with any IDs sourced from the allow-list file (see
+      the allow_list_* inputs); duplicates are de-duplicated.
     # type: string
     required: false
     default: 'GHSA-4xh5-x5gv-qwph'
+  allow_list_path:
+    description: >
+      Local filesystem path to a vulnerability allow-list file. When
+      set, takes precedence over allow_list_url and allow_list_org.
+      File format: whitespace-separated vulnerability IDs (CVE-,
+      GHSA-, PYSEC-, OSV-, PVE-); '#' introduces a comment (full-line
+      or trailing). Must not contain newline characters.
+    # type: string
+    required: false
+    default: ''
+  allow_list_url:
+    description: >
+      Remote HTTPS URL to download the allow-list from. Ignored when
+      allow_list_path is set. When both allow_list_path and
+      allow_list_url are empty the action constructs a default URL
+      from allow_list_org (see below). Must not contain newline
+      characters.
+    # type: string
+    required: false
+    default: ''
+  allow_list_org:
+    description: >
+      GitHub organisation/owner used to construct the default
+      allow-list URL when neither allow_list_path nor allow_list_url
+      is supplied. Defaults at runtime to github.repository_owner.
+      Default URL pattern:
+      https://raw.githubusercontent.com/<org>/.github/HEAD/.github/python-audit/<org>/allow_list.txt
+    # type: string
+    required: false
+    default: ''
+  allow_list_disable:
+    description: >
+      When 'true', skip allow-list loading entirely and use only the
+      'ignore_vulns' input.
+    # type: boolean
+    required: false
+    default: 'false'
 
 runs:
   using: 'composite'
@@ -105,6 +145,207 @@ runs:
           pip install -q -r "$req_file"
         fi
 
+    - name: 'Resolve vulnerability allow-list'
+      id: allow_list
+      shell: bash
+      env:
+        ALLOW_LIST_PATH: "${{ inputs.allow_list_path }}"
+        ALLOW_LIST_URL: "${{ inputs.allow_list_url }}"
+        ALLOW_LIST_ORG: "${{ inputs.allow_list_org }}"
+        ALLOW_LIST_DISABLE: "${{ inputs.allow_list_disable }}"
+        REPO_OWNER: "${{ github.repository_owner }}"
+      run: |
+        # Resolve vulnerability allow-list
+        #
+        # Precedence:
+        #   allow_list_path > allow_list_url > default URL from org.
+        # Soft-fail rule:
+        #   The default-URL case (no path, no url) treats fetch
+        #   failures as "no allow-list" and proceeds silently. An
+        #   explicitly-supplied path or url is a hard failure when
+        #   it cannot be loaded, since the caller asked for it.
+        # Sanitisation:
+        #   Every token is matched against a strict allow-list of
+        #   vulnerability ID shapes (CVE-/GHSA-/PYSEC-/OSV-/PVE-).
+        #   Non-conforming content fails the step rather than being
+        #   silently dropped.
+        set -euo pipefail
+
+        emit() {
+          # Append a key=value pair to GITHUB_OUTPUT, refusing values
+          # containing newlines (none of our outputs ever need them).
+          local key="$1"
+          local value="$2"
+          if printf '%s' "$value" | grep -q $'[\r\n]'; then
+            echo "::error::Refusing to write multi-line output for ${key}"
+            exit 1
+          fi
+          printf '%s=%s\n' "$key" "$value" >> "$GITHUB_OUTPUT"
+        }
+
+        summary_line() {
+          if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+            printf '%s\n' "$1" >> "$GITHUB_STEP_SUMMARY"
+          fi
+        }
+
+        if [ "$ALLOW_LIST_DISABLE" = "true" ]; then
+          echo "Allow-list loading disabled via allow_list_disable input"
+          emit "ids" ""
+          emit "source" "disabled"
+          emit "resolved_url" ""
+          emit "count" "0"
+          exit 0
+        fi
+
+        # Reject newlines in path/url inputs to keep downstream
+        # GITHUB_OUTPUT writes safe.
+        for name in ALLOW_LIST_PATH ALLOW_LIST_URL; do
+          value="${!name}"
+          if printf '%s' "$value" | grep -q $'[\r\n]'; then
+            echo "::error::Input '${name}' must not contain newline characters"
+            exit 1
+          fi
+        done
+
+        source=""
+        resolved_url=""
+        raw=""
+        soft_fail="false"
+
+        if [ -n "$ALLOW_LIST_PATH" ]; then
+          source="path"
+          if [ ! -f "$ALLOW_LIST_PATH" ]; then
+            echo "::error::Allow-list file not found at: ${ALLOW_LIST_PATH}"
+            exit 1
+          fi
+          raw=$(cat -- "$ALLOW_LIST_PATH")
+          echo "Source: local path -> ${ALLOW_LIST_PATH}"
+        else
+          if [ -n "$ALLOW_LIST_URL" ]; then
+            source="url"
+            resolved_url="$ALLOW_LIST_URL"
+          else
+            org="${ALLOW_LIST_ORG:-$REPO_OWNER}"
+            # GitHub org/user names: 1-39 chars, alphanumerics and
+            # hyphens, no leading/trailing hyphen, no consecutive
+            # hyphens. A bad org name produces a URL that can never
+            # resolve; reject it up front.
+            if ! printf '%s' "$org" \
+              | grep -Eq '^[A-Za-z0-9](-?[A-Za-z0-9]){0,38}$'; then
+              echo "::error::Resolved org name is invalid: '${org}'"
+              exit 1
+            fi
+            resolved_url="https://raw.githubusercontent.com/${org}/.github/HEAD/.github/python-audit/${org}/allow_list.txt"
+            source="default-url"
+            soft_fail="true"
+          fi
+
+          # HTTPS-only, 15s timeout, 1 MiB size ceiling, follow
+          # redirects. --fail turns 4xx/5xx into curl exit codes.
+          tmp=$(mktemp)
+          trap 'rm -f "$tmp"' EXIT
+          set +e
+          curl --proto '=https' --tlsv1.2 \
+            -sSfL --max-time 15 --max-filesize 1048576 \
+            -H 'User-Agent: lfreleng-actions/python-audit-action' \
+            -H 'Accept: text/plain, */*;q=0.5' \
+            -o "$tmp" \
+            "$resolved_url"
+          rc=$?
+          set -e
+          if [ "$rc" -ne 0 ]; then
+            if [ "$soft_fail" = "true" ]; then
+              # No allow-list published for this org; proceed
+              # silently with whatever ignore_vulns provided.
+              echo "No central allow-list at default URL;" \
+                   "proceeding without it"
+              emit "ids" ""
+              emit "source" "default-url-missing"
+              emit "resolved_url" "$resolved_url"
+              emit "count" "0"
+              exit 0
+            fi
+            echo "::error::Failed to fetch allow-list from" \
+                 "${resolved_url} (curl exit ${rc})"
+            exit 1
+          fi
+          raw=$(cat -- "$tmp")
+          echo "Source: ${source} -> ${resolved_url}"
+        fi
+
+        # Strip UTF-8 BOM, strip '#' comments (full-line and
+        # trailing), collapse whitespace.
+        cleaned=$(printf '%s' "$raw" \
+          | sed -e '1s/^\xEF\xBB\xBF//' \
+                -e 's/[[:space:]]#[^\r\n]*//g' \
+                -e 's/^#[^\r\n]*//g' \
+          | tr '[:space:]' '\n' \
+          | sed '/^$/d')
+
+        ids=""
+        count=0
+        # Strict allow-list of vulnerability ID shapes. Any token
+        # that does not match one of these is a hard failure.
+        id_re='^('
+        id_re+='CVE-[0-9]{4}-[0-9]{4,}'
+        id_re+='|GHSA-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+        id_re+='|PYSEC-[0-9]{4}-[0-9]+'
+        id_re+='|OSV-[0-9]{4}-[0-9]+'
+        id_re+='|PVE-[0-9]+'
+        id_re+=')$'
+        while IFS= read -r token; do
+          [ -z "$token" ] && continue
+          if ! printf '%s' "$token" | grep -Eq "$id_re"; then
+            echo "::error::Rejected allow-list token '${token}'" \
+                 "(not a recognised CVE/GHSA/PYSEC/OSV/PVE ID)"
+            exit 1
+          fi
+          if [ -z "$ids" ]; then
+            ids="$token"
+          else
+            ids="${ids} ${token}"
+          fi
+          count=$((count + 1))
+        done <<< "$cleaned"
+
+        echo "Loaded ${count} allow-list entries from source '${source}'"
+        emit "ids" "$ids"
+        emit "source" "$source"
+        emit "resolved_url" "$resolved_url"
+        emit "count" "$count"
+
+        summary_line "### 🐍 Python audit allow-list"
+        summary_line ""
+        if [ -n "$resolved_url" ]; then
+          summary_line "- Source: \`${source}\` (\`${resolved_url}\`)"
+        else
+          summary_line "- Source: \`${source}\`"
+        fi
+        summary_line "- Entries loaded: **${count}**"
+        summary_line ""
+
+    - name: 'Merge ignore_vulns with allow-list'
+      id: merged
+      shell: bash
+      env:
+        BASE_IGNORE: "${{ inputs.ignore_vulns }}"
+        ALLOW_LIST_IDS: "${{ steps.allow_list.outputs.ids }}"
+      run: |
+        # Merge ignore_vulns with allow-list IDs (whitespace-
+        # separated, de-duplicated, order-preserving).
+        set -euo pipefail
+        merged=$(printf '%s %s' "$BASE_IGNORE" "$ALLOW_LIST_IDS" \
+          | tr '[:space:]' '\n' \
+          | awk 'NF && !seen[$0]++' \
+          | paste -sd' ' -)
+        echo "ignore_vulns=${merged}" >> "$GITHUB_OUTPUT"
+        if [ -n "$merged" ]; then
+          echo "Effective ignore_vulns: ${merged}"
+        else
+          echo "Effective ignore_vulns: (none)"
+        fi
+
     - name: 'Auditing with: pypa/gh-action-pip-audit'
       if: ${{ inputs.permit_fail == 'false' }}
       # yamllint disable-line rule:line-length
@@ -112,7 +353,7 @@ runs:
       with:
         inputs: "${{ inputs.path_prefix }}"
         summary: "${{ inputs.summary }}"
-        ignore-vulns: "${{ inputs.ignore_vulns }}"
+        ignore-vulns: "${{ steps.merged.outputs.ignore_vulns }}"
 
     - name: 'Auditing with: pypa/gh-action-pip-audit'
       if: ${{ inputs.permit_fail == 'true' }}
@@ -122,4 +363,4 @@ runs:
       with:
         inputs: "${{ inputs.path_prefix }}"
         summary: "${{ inputs.summary }}"
-        ignore-vulns: "${{ inputs.ignore_vulns }}"
+        ignore-vulns: "${{ steps.merged.outputs.ignore_vulns }}"

--- a/action.yaml
+++ b/action.yaml
@@ -83,6 +83,46 @@ inputs:
     # type: boolean
     required: false
     default: 'false'
+  config:
+    description: >
+      GitHub-Actions uses-style coordinate identifying a remote
+      allow-list file, fetched with a shallow, ref-pinned git fetch
+      (supports branch, tag or commit SHA). Mutually exclusive with
+      the allow_list_* inputs; supplying any of them together with
+      'config' is an error. See the README for the full grammar.
+    # type: string
+    required: false
+    default: ''
+  token:
+    description: >
+      Token used to authenticate the git fetch when 'config' targets
+      a private host repository. Leave empty for public repositories.
+      GITHUB_TOKEN only grants access to the current repository;
+      reading a private config repo in another org needs a PAT or
+      GitHub App token with contents:read on that repo.
+    # type: string
+    required: false
+    default: ''
+
+outputs:
+  resolved_host_org:
+    description: 'Host org the config file was fetched from'
+    value: "${{ steps.config_resolve.outputs.host_org }}"
+  resolved_repo:
+    description: 'Repository the config file was fetched from'
+    value: "${{ steps.config_resolve.outputs.repo }}"
+  resolved_ref:
+    description: 'Git ref requested for the config fetch'
+    value: "${{ steps.config_resolve.outputs.ref }}"
+  resolved_sha:
+    description: 'Exact commit SHA the config ref resolved to'
+    value: "${{ steps.config_resolve.outputs.resolved_sha }}"
+  resolved_path:
+    description: 'In-repo path of the matched config file'
+    value: "${{ steps.config_resolve.outputs.resolved_path }}"
+  matched_candidate:
+    description: 'Search candidate that matched'
+    value: "${{ steps.config_resolve.outputs.matched_candidate }}"
 
 runs:
   using: 'composite'
@@ -145,8 +185,63 @@ runs:
           pip install -q -r "$req_file"
         fi
 
+    - name: 'Resolve allow-list via config'
+      id: config_resolve
+      if: ${{ inputs.config != '' }}
+      shell: bash
+      env:
+        CONFIG: "${{ inputs.config }}"
+        TOKEN: "${{ inputs.token }}"
+        REPO_OWNER: "${{ github.repository_owner }}"
+        AL_PATH: "${{ inputs.allow_list_path }}"
+        AL_URL: "${{ inputs.allow_list_url }}"
+        AL_ORG: "${{ inputs.allow_list_org }}"
+        AL_DISABLE: "${{ inputs.allow_list_disable }}"
+        ACTION_PATH: "${{ github.action_path }}"
+      run: |
+        # Resolve allow-list via the 'config' uses-style coordinate.
+        set -euo pipefail
+
+        # Mask the token before anything else so it cannot leak.
+        if [ -n "$TOKEN" ]; then
+          echo "::add-mask::$TOKEN"
+        fi
+
+        # Exclusivity: 'config' must not combine with allow_list_*.
+        if [ -n "$AL_PATH" ] || [ -n "$AL_URL" ] || [ -n "$AL_ORG" ] \
+            || [ "$AL_DISABLE" = "true" ]; then
+          echo "::error::'config' is mutually exclusive with the" \
+               "allow_list_* inputs; specify only one mechanism"
+          exit 1
+        fi
+
+        # Preflight: the shared resolver needs python3 on the runner.
+        if ! command -v python3 >/dev/null 2>&1; then
+          echo "::error::python3 is required for the 'config' input" \
+               "but was not found on this runner"
+          exit 1
+        fi
+
+        # The shared resolver writes ids/count/resolved_* to
+        # GITHUB_OUTPUT and a block to GITHUB_STEP_SUMMARY. A missing
+        # file at an auto-derived path exits 0 with empty ids (soft);
+        # an explicitly-named missing file or any validation/network
+        # failure exits non-zero and fails this step.
+        python3 "${ACTION_PATH}/src/resolve_config_source.py" \
+          --config "$CONFIG" \
+          --workflow-org "$REPO_OWNER" \
+          --family python-audit \
+          --mode vulns \
+          --token-env TOKEN \
+          --content-key ids \
+          --summary-title "🐍 Python audit allow-list" \
+          --summary-unit Entries \
+          --github-output "$GITHUB_OUTPUT" \
+          --step-summary "$GITHUB_STEP_SUMMARY"
+
     - name: 'Resolve vulnerability allow-list'
       id: allow_list
+      if: ${{ inputs.config == '' }}
       shell: bash
       env:
         ALLOW_LIST_PATH: "${{ inputs.allow_list_path }}"
@@ -330,7 +425,8 @@ runs:
       shell: bash
       env:
         BASE_IGNORE: "${{ inputs.ignore_vulns }}"
-        ALLOW_LIST_IDS: "${{ steps.allow_list.outputs.ids }}"
+        # yamllint disable-line rule:line-length
+        ALLOW_LIST_IDS: "${{ steps.allow_list.outputs.ids }} ${{ steps.config_resolve.outputs.ids }}"
       run: |
         # Merge ignore_vulns with allow-list IDs (whitespace-
         # separated, de-duplicated, order-preserving).

--- a/action.yaml
+++ b/action.yaml
@@ -50,9 +50,10 @@ inputs:
     description: >
       Local filesystem path to a vulnerability allow-list file. When
       set, takes precedence over allow_list_url and allow_list_org.
-      File format: whitespace-separated vulnerability IDs (CVE-,
-      GHSA-, PYSEC-, OSV-, PVE-); '#' introduces a comment (full-line
-      or trailing). Must not contain newline characters.
+      The path string itself must not contain newline characters; the
+      file it points to may be multi-line. File format:
+      whitespace-separated vulnerability IDs (CVE-, GHSA-, PYSEC-,
+      OSV-, PVE-); '#' introduces a comment (full-line or trailing).
     # type: string
     required: false
     default: ''
@@ -61,8 +62,8 @@ inputs:
       Remote HTTPS URL to download the allow-list from. Ignored when
       allow_list_path is set. When both allow_list_path and
       allow_list_url are empty the action constructs a default URL
-      from allow_list_org (see below). Must not contain newline
-      characters.
+      from allow_list_org (see below). The URL string itself must not
+      contain newline characters.
     # type: string
     required: false
     default: ''
@@ -88,8 +89,10 @@ inputs:
       GitHub-Actions uses-style coordinate identifying a remote
       allow-list file, fetched with a shallow, ref-pinned git fetch
       (supports branch, tag or commit SHA). Mutually exclusive with
-      the allow_list_* inputs; supplying any of them together with
-      'config' is an error. See the README for the full grammar.
+      the allow_list_path, allow_list_url, allow_list_org and
+      allow_list_disable inputs; supplying any of them together with
+      'config' is an error (allow_list_summary is still honoured). See
+      the README for the full grammar.
     # type: string
     required: false
     default: ''
@@ -108,8 +111,8 @@ inputs:
       Whether to write the allow-list/config block to the job step
       summary. Set to 'false' to suppress it. Useful for matrix jobs,
       where the same block would otherwise repeat once per leg; emit
-      it on a single leg with, e.g.,
-      allow_list_summary: ${{ strategy.job-index == 0 }}.
+      it on a single matrix leg only (see the README for the
+      strategy.job-index pattern).
     # type: boolean
     required: false
     default: 'true'
@@ -117,13 +120,13 @@ inputs:
 outputs:
   resolved_host_org:
     description: 'Host org the config file was fetched from'
-    value: "${{ steps.config_resolve.outputs.host_org }}"
+    value: "${{ steps.config_resolve.outputs.resolved_host_org }}"
   resolved_repo:
     description: 'Repository the config file was fetched from'
-    value: "${{ steps.config_resolve.outputs.repo }}"
+    value: "${{ steps.config_resolve.outputs.resolved_repo }}"
   resolved_ref:
     description: 'Git ref requested for the config fetch'
-    value: "${{ steps.config_resolve.outputs.ref }}"
+    value: "${{ steps.config_resolve.outputs.resolved_ref }}"
   resolved_sha:
     description: 'Exact commit SHA the config ref resolved to'
     value: "${{ steps.config_resolve.outputs.resolved_sha }}"
@@ -218,11 +221,13 @@ runs:
           echo "::add-mask::$TOKEN"
         fi
 
-        # Exclusivity: 'config' must not combine with allow_list_*.
+        # Exclusivity: 'config' must not combine with the allow-list
+        # source inputs (allow_list_summary is still honoured).
         if [ -n "$AL_PATH" ] || [ -n "$AL_URL" ] || [ -n "$AL_ORG" ] \
             || [ "$AL_DISABLE" = "true" ]; then
-          echo "::error::'config' is mutually exclusive with the" \
-               "allow_list_* inputs; specify only one mechanism"
+          echo "::error::'config' is mutually exclusive with" \
+               "allow_list_path/allow_list_url/allow_list_org/" \
+               "allow_list_disable; specify only one mechanism"
           exit 1
         fi
 
@@ -274,10 +279,13 @@ runs:
         # Precedence:
         #   allow_list_path > allow_list_url > default URL from org.
         # Soft-fail rule:
-        #   The default-URL case (no path, no url) treats fetch
-        #   failures as "no allow-list" and proceeds silently. An
-        #   explicitly-supplied path or url is a hard failure when
-        #   it cannot be loaded, since the caller asked for it.
+        #   In the default-URL case (no path, no url), only an HTTP 404
+        #   from the default URL is a soft miss (no central file
+        #   published) and proceeds silently. Transport failures
+        #   (DNS/TLS/timeout/max-filesize) and any other HTTP status
+        #   are hard errors. An explicitly-supplied path or url is a
+        #   hard failure when it cannot be loaded, since the caller
+        #   asked for it.
         # Sanitisation:
         #   Every token is matched against a strict allow-list of
         #   vulnerability ID shapes (CVE-/GHSA-/PYSEC-/OSV-/PVE-).
@@ -290,7 +298,7 @@ runs:
           # containing newlines (none of our outputs ever need them).
           local key="$1"
           local value="$2"
-          if printf '%s' "$value" | grep -q $'[\r\n]'; then
+          if [[ "$value" == *$'\n'* || "$value" == *$'\r'* ]]; then
             echo "::error::Refusing to write multi-line output for ${key}"
             exit 1
           fi
@@ -316,10 +324,12 @@ runs:
         fi
 
         # Reject newlines in path/url inputs to keep downstream
-        # GITHUB_OUTPUT writes safe.
+        # GITHUB_OUTPUT writes safe. Test the whole value with bash
+        # pattern matching: a line-by-line grep would accept a value
+        # whose first line is valid but which embeds a newline.
         for name in ALLOW_LIST_PATH ALLOW_LIST_URL; do
           value="${!name}"
-          if printf '%s' "$value" | grep -q $'[\r\n]'; then
+          if [[ "$value" == *$'\n'* || "$value" == *$'\r'* ]]; then
             echo "::error::Input '${name}' must not contain newline characters"
             exit 1
           fi
@@ -347,7 +357,22 @@ runs:
             # GitHub org/user names: 1-39 chars, alphanumerics and
             # hyphens, no leading/trailing hyphen, no consecutive
             # hyphens. A bad org name produces a URL that can never
-            # resolve; reject it up front.
+            # resolve; reject it up front. Reject newlines first with
+            # bash pattern matching, since the line-by-line grep below
+            # would otherwise accept a multi-line value whose first
+            # line happens to be a valid org.
+            if [[ "$org" == *$'\n'* || "$org" == *$'\r'* ]]; then
+              echo "::error::Org name must not contain newline characters"
+              exit 1
+            fi
+            # Enforce the 1-39 character limit explicitly: the ERE
+            # below cannot (its repeated group may consume a hyphen
+            # plus an alphanumeric, so it would otherwise admit names
+            # longer than 39 characters).
+            if [ "${#org}" -lt 1 ] || [ "${#org}" -gt 39 ]; then
+              echo "::error::Resolved org name length invalid: '${org}'"
+              exit 1
+            fi
             if ! printf '%s' "$org" \
               | grep -Eq '^[A-Za-z0-9](-?[A-Za-z0-9]){0,38}$'; then
               echo "::error::Resolved org name is invalid: '${org}'"
@@ -359,32 +384,46 @@ runs:
           fi
 
           # HTTPS-only, 15s timeout, 1 MiB size ceiling, follow
-          # redirects. --fail turns 4xx/5xx into curl exit codes.
+          # redirects. We deliberately omit --fail and capture the HTTP
+          # status separately so that a genuine "file absent" (404) can
+          # be distinguished from transport failures (DNS/TLS/timeout/
+          # max-filesize). Only a 404 at the default URL is a soft
+          # miss; transport errors and other HTTP statuses are hard
+          # failures even in default-url mode.
           tmp=$(mktemp)
           trap 'rm -f "$tmp"' EXIT
           set +e
-          curl --proto '=https' --tlsv1.2 \
-            -sSfL --max-time 15 --max-filesize 1048576 \
+          http_code=$(curl --proto '=https' --tlsv1.2 \
+            -sSL --max-time 15 --max-filesize 1048576 \
             -H 'User-Agent: lfreleng-actions/python-audit-action' \
             -H 'Accept: text/plain, */*;q=0.5' \
+            -w '%{http_code}' \
             -o "$tmp" \
-            "$resolved_url"
+            -- "$resolved_url")
           rc=$?
           set -e
           if [ "$rc" -ne 0 ]; then
-            if [ "$soft_fail" = "true" ]; then
-              # No allow-list published for this org; proceed
-              # silently with whatever ignore_vulns provided.
-              echo "No central allow-list at default URL;" \
-                   "proceeding without it"
-              emit "ids" ""
-              emit "source" "default-url-missing"
-              emit "resolved_url" "$resolved_url"
-              emit "count" "0"
-              exit 0
-            fi
+            # Transport failure (could not resolve/connect, TLS error,
+            # timeout, or response exceeded --max-filesize). Never a
+            # soft miss, since the file's presence is unknown.
             echo "::error::Failed to fetch allow-list from" \
                  "${resolved_url} (curl exit ${rc})"
+            exit 1
+          fi
+          if [ "$http_code" = "404" ] && [ "$soft_fail" = "true" ]; then
+            # No allow-list published for this org; proceed with
+            # whatever ignore_vulns provided.
+            echo "No central allow-list at default URL (HTTP 404);" \
+                 "proceeding without it"
+            emit "ids" ""
+            emit "source" "default-url-missing"
+            emit "resolved_url" "$resolved_url"
+            emit "count" "0"
+            exit 0
+          fi
+          if [ "$http_code" != "200" ]; then
+            echo "::error::Failed to fetch allow-list from" \
+                 "${resolved_url} (HTTP ${http_code})"
             exit 1
           fi
           raw=$(cat -- "$tmp")
@@ -409,7 +448,7 @@ runs:
         id_re+='|GHSA-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
         id_re+='|PYSEC-[0-9]{4}-[0-9]+'
         id_re+='|OSV-[0-9]{4}-[0-9]+'
-        id_re+='|PVE-[0-9]+'
+        id_re+='|PVE-[0-9]+(-[0-9]+)?'
         id_re+=')$'
         while IFS= read -r token; do
           [ -z "$token" ] && continue
@@ -425,6 +464,15 @@ runs:
           fi
           count=$((count + 1))
         done <<< "$cleaned"
+
+        # An allow-list file that parses to zero tokens (for example,
+        # a file containing only comments) is a misconfiguration. The
+        # shared config-mode resolver rejects this too, so keep the
+        # validation semantics identical across loading mechanisms.
+        if [ "$count" -eq 0 ]; then
+          echo "::error::Allow-list is empty after parsing (source: ${source})"
+          exit 1
+        fi
 
         echo "Loaded ${count} allow-list entries from source '${source}'"
         emit "ids" "$ids"

--- a/src/resolve_config_source.py
+++ b/src/resolve_config_source.py
@@ -1,0 +1,572 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+#
+# ╔══════════════════════════════════════════════════════════════════╗
+# ║  SYNCHRONISED FILE — DO NOT EDIT IN ISOLATION                      ║
+# ║                                                                    ║
+# ║  This file is mirrored, byte-for-byte, across two repositories:    ║
+# ║    - lfreleng-actions/python-audit-action       : src/...          ║
+# ║    - lfreleng-actions/harden-runner-block-action: src/...          ║
+# ║                                                                    ║
+# ║  The `config` input grammar and its resolution/fetch/sanitise      ║
+# ║  behaviour MUST stay identical in both actions. Any change here    ║
+# ║  has to be raised as PAIRED pull requests in BOTH repositories.    ║
+# ║  A CI check in each repo diffs this file against the other repo's  ║
+# ║  copy and fails the build if they diverge.                         ║
+# ║                                                                    ║
+# ║  The only action-specific behaviour is selected at call time via   ║
+# ║  the --mode flag (endpoints | vulns); the module itself carries    ║
+# ║  no per-action constants.                                          ║
+# ╚══════════════════════════════════════════════════════════════════╝
+#
+# resolve_config_source.py
+#
+# Resolves the `config` input (a GitHub-Actions `uses:`-style coordinate)
+# into a concrete (host-org, repo, ref, in-repo path) tuple, fetches the
+# referenced file from GitHub using a shallow, ref-pinned git fetch, and
+# sanitises the content against a strict, mode-selected token grammar.
+#
+# The module performs NO publishing of its own: it prints results to the
+# destinations its caller selects (JSON to stdout, key=value lines to a
+# GITHUB_OUTPUT file, a markdown block to a GITHUB_STEP_SUMMARY file).
+# Diagnostics and errors go to stderr. Workflow commands (::error::,
+# ::add-mask::) are intentionally NOT emitted here so that stdout stays
+# clean JSON for the Node.js consumer; the calling wrapper is responsible
+# for masking the token and surfacing errors as workflow annotations.
+#
+# Exit codes:
+#   0  success (file found and sanitised) OR a "soft" not-found at an
+#      auto-derived path (the JSON carries found=false; the caller
+#      decides whether that is fatal for its action)
+#   1  hard error (bad input, validation failure, network/git failure)
+
+# pyright: basic
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+
+# Hard ceiling on the file size we will read out of the fetched tree, to
+# stop a misconfigured or hostile repo from exhausting runner memory.
+MAX_FILE_BYTES = 1_048_576  # 1 MiB
+
+# GitHub org/user names: 1-39 chars, alphanumerics and single hyphens,
+# no leading/trailing hyphen, no consecutive hyphens.
+ORG_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}$")
+
+# Repository names: alphanumerics plus '.', '_', '-'. The canonical host
+# repo is the special '.github' repo, so a leading dot must be allowed.
+REPO_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+# A single in-repo path segment. No empty segments, no '..', no slashes
+# (the path is split on '/' before validation), no shell metacharacters.
+SEGMENT_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+# Git ref: branch name, tag name, or commit SHA. Conservative subset of
+# the characters git permits, sufficient for our use and safe to hand to
+# the git CLI as a positional argument.
+REF_RE = re.compile(r"^[A-Za-z0-9._/-]+$")
+
+
+class ResolveError(Exception):
+    """A hard error that must fail the action."""
+
+
+# ---------------------------------------------------------------------
+# Parsing
+# ---------------------------------------------------------------------
+
+def split_comment(value: str) -> tuple[str, str]:
+    """Split a trailing ' #...' comment (one or more spaces before '#').
+
+    Returns (spec, comment). The comment (without the leading whitespace
+    and '#') is informational only and never affects resolution.
+    """
+    # Match the first run of whitespace followed by '#', to end of string.
+    m = re.search(r"\s+#(.*)$", value)
+    if m:
+        return value[: m.start()], m.group(1).strip()
+    return value, ""
+
+
+def parse_config(spec: str) -> dict:
+    """Parse a `config` spec into its raw components.
+
+    Grammar:
+        <spec>     ::= <source> [ "@" <ref> ]
+        <source>   ::= <repospec> [ "//" <subpath> ]
+        <repospec> ::= [ <host-org> [ "/" <repo> ] ]
+        <subpath>  ::= [ <dir> "/" ]... [ <filename> ]
+    """
+    if "\n" in spec or "\r" in spec:
+        raise ResolveError("config must not contain newline characters")
+
+    # Separate an optional '@<ref>'. '@' may appear at most once.
+    ref = ""
+    if "@" in spec:
+        source, _, ref = spec.partition("@")
+        if "@" in ref:
+            raise ResolveError("config contains more than one '@' separator")
+        if ref == "":
+            raise ResolveError("config has an empty ref after '@'")
+    else:
+        source = spec
+
+    # Separate repospec from subpath on '//'. '//' may appear at most once.
+    subpath = ""
+    has_subpath = False
+    if "//" in source:
+        repospec, _, subpath = source.partition("//")
+        has_subpath = True
+        if "//" in subpath:
+            raise ResolveError("config contains more than one '//' separator")
+    else:
+        repospec = source
+
+    return {
+        "repospec": repospec,
+        "subpath": subpath,
+        "has_subpath": has_subpath,
+        "ref": ref,
+    }
+
+
+def resolve(
+    spec: str,
+    *,
+    workflow_org: str,
+    family: str,
+    default_repo: str = ".github",
+    default_filename: str = "allow_list.txt",
+) -> dict:
+    """Resolve a parsed config spec into concrete fetch coordinates.
+
+    Returns a dict with: host_org, repo, ref, candidates (ordered list of
+    in-repo paths to try), path_explicit (bool), comment.
+    """
+    spec, comment = split_comment(spec.strip())
+    if spec == "":
+        raise ResolveError("config is empty")
+
+    parts = parse_config(spec)
+
+    # --- host-org and repo (the part before '//') ---
+    repospec = parts["repospec"].strip("/")
+    if repospec == "":
+        host_org = workflow_org
+        repo = default_repo
+    else:
+        segs = repospec.split("/")
+        if len(segs) == 1:
+            host_org, repo = segs[0], default_repo
+        elif len(segs) == 2:
+            host_org, repo = segs[0], segs[1]
+        else:
+            raise ResolveError(
+                "config repository part accepts at most '<org>/<repo>'; "
+                "put any in-repo path after '//'"
+            )
+
+    if host_org == "":
+        host_org = workflow_org
+    if not ORG_RE.match(host_org):
+        raise ResolveError(f"invalid host org in config: '{host_org}'")
+    if repo == "":
+        repo = default_repo
+    if repo in ("..", ".") or not REPO_RE.match(repo):
+        raise ResolveError(f"invalid repository in config: '{repo}'")
+
+    # --- ref ---
+    ref = parts["ref"] or "HEAD"
+    if ref != "HEAD":
+        if ref.startswith("-") or ref.startswith("/") or ".." in ref \
+                or "@{" in ref or len(ref) > 255 or not REF_RE.match(ref):
+            raise ResolveError(f"invalid git ref in config: '{ref}'")
+
+    # --- subpath -> filename + directory + search candidates ---
+    default_dir_specific = f".github/{family}/{workflow_org}"
+    default_dir_family = f".github/{family}"
+
+    subpath = parts["subpath"]
+    path_explicit = False
+
+    if not parts["has_subpath"] or subpath == "":
+        # No subpath, or a bare '//': default dir search chain + default file.
+        filename = default_filename
+        candidates = [
+            f"{default_dir_specific}/{filename}",
+            f"{default_dir_family}/{filename}",
+        ]
+    elif "/" not in subpath:
+        # Filename only: override the filename, keep the default dir search.
+        filename = subpath
+        candidates = [
+            f"{default_dir_specific}/{filename}",
+            f"{default_dir_family}/{filename}",
+        ]
+    else:
+        # Explicit directory present: use exactly this path, no search.
+        path_explicit = True
+        candidates = [subpath]
+
+    # Validate every candidate path segment.
+    for cand in candidates:
+        if cand.startswith("/") or "\\" in cand or ".." in cand.split("/"):
+            raise ResolveError(f"invalid in-repo path in config: '{cand}'")
+        segs = cand.split("/")
+        if not segs or any(seg == "" for seg in segs):
+            raise ResolveError(f"invalid in-repo path in config: '{cand}'")
+        for seg in segs:
+            if not SEGMENT_RE.match(seg):
+                raise ResolveError(
+                    f"invalid path segment '{seg}' in config path '{cand}'"
+                )
+
+    if workflow_org != "" and not ORG_RE.match(workflow_org):
+        raise ResolveError(f"invalid workflow org: '{workflow_org}'")
+
+    return {
+        "host_org": host_org,
+        "repo": repo,
+        "ref": ref,
+        "candidates": candidates,
+        "path_explicit": path_explicit,
+        "comment": comment,
+    }
+
+
+# ---------------------------------------------------------------------
+# Fetch (shallow, ref-pinned, git over HTTPS)
+# ---------------------------------------------------------------------
+
+def _run_git(args: list[str], timeout: int) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def fetch_file(
+    *,
+    host_org: str,
+    repo: str,
+    ref: str,
+    candidates: list[str],
+    token: str = "",
+    timeout: int = 30,
+) -> dict:
+    """Shallow-fetch `ref` and return the first existing candidate file.
+
+    Works uniformly for branches, tags and commit SHAs: GitHub honours
+    `git fetch --depth 1 <sha>` for reachable commits. Returns a dict with
+    found (bool), resolved_sha, matched_path, content (str | None).
+    """
+    url = f"https://github.com/{host_org}/{repo}.git"
+    with tempfile.TemporaryDirectory() as tmp:
+        def git(args: list[str]) -> subprocess.CompletedProcess:
+            return _run_git(["-C", tmp, *args], timeout)
+
+        if git(["init", "-q"]).returncode != 0:
+            raise ResolveError("git init failed")
+        if git(["remote", "add", "origin", url]).returncode != 0:
+            raise ResolveError("git remote add failed")
+
+        if token:
+            # Inject auth as a config header (never on the command line or
+            # in the URL, so it cannot leak via process listings or logs).
+            basic = base64.b64encode(
+                f"x-access-token:{token}".encode()
+            ).decode()
+            cfg = git([
+                "config", "--local",
+                "http.https://github.com/.extraheader",
+                f"AUTHORIZATION: basic {basic}",
+            ])
+            if cfg.returncode != 0:
+                raise ResolveError("git auth header configuration failed")
+
+        fetched = git([
+            "-c", "protocol.version=2",
+            "fetch", "-q", "--depth", "1", "origin", ref,
+        ])
+        if fetched.returncode != 0:
+            raise ResolveError(
+                f"git fetch of '{ref}' from {host_org}/{repo} failed: "
+                f"{fetched.stderr.strip()}"
+            )
+
+        rev = git(["rev-parse", "FETCH_HEAD"])
+        if rev.returncode != 0:
+            raise ResolveError("could not resolve FETCH_HEAD to a commit SHA")
+        resolved_sha = rev.stdout.strip()
+
+        for cand in candidates:
+            exists = git(["cat-file", "-e", f"FETCH_HEAD:{cand}"])
+            if exists.returncode != 0:
+                continue
+            size = git(["cat-file", "-s", f"FETCH_HEAD:{cand}"])
+            try:
+                if size.returncode == 0 and int(size.stdout.strip()) > MAX_FILE_BYTES:
+                    raise ResolveError(
+                        f"config file '{cand}' exceeds {MAX_FILE_BYTES}-byte limit"
+                    )
+            except ValueError:
+                pass
+            shown = git(["show", f"FETCH_HEAD:{cand}"])
+            if shown.returncode != 0:
+                continue
+            return {
+                "found": True,
+                "resolved_sha": resolved_sha,
+                "matched_path": cand,
+                "content": shown.stdout,
+            }
+
+        return {
+            "found": False,
+            "resolved_sha": resolved_sha,
+            "matched_path": "",
+            "content": None,
+        }
+
+
+# ---------------------------------------------------------------------
+# Sanitisation (mode-selected)
+# ---------------------------------------------------------------------
+
+def _strip_comments_and_split(raw: str) -> list[str]:
+    text = raw.lstrip("\ufeff")
+    # Remove '#' comments (full-line and trailing-after-whitespace).
+    text = re.sub(r"(^|[ \t])#[^\r\n]*", r"\1", text, flags=re.MULTILINE)
+    text = re.sub(r"\s+", " ", text).strip()
+    if text == "":
+        return []
+    return text.split(" ")
+
+
+_HOST_BARE = r"[A-Za-z0-9][A-Za-z0-9.-]*"
+_HOST_WILD = r"\*\.[A-Za-z0-9][A-Za-z0-9.-]*"
+_ENDPOINT_RE = re.compile(
+    rf"^(?:{_HOST_BARE}|{_HOST_WILD})(?::[0-9]{{1,5}})?$"
+)
+
+_VULN_RE = re.compile(
+    r"^(?:"
+    r"CVE-[0-9]{4}-[0-9]{4,}"
+    r"|GHSA-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}"
+    r"|PYSEC-[0-9]{4}-[0-9]+"
+    r"|OSV-[0-9]{4}-[0-9]+"
+    r"|PVE-[0-9]+(?:-[0-9]+)?"
+    r")$"
+)
+
+
+def sanitise(raw: str, mode: str) -> list[str]:
+    """Validate every token in the file against the mode's grammar.
+
+    A single non-conforming token is a hard error rather than being
+    silently dropped, so untrusted remote content cannot smuggle
+    unexpected values into a downstream tool.
+    """
+    tokens = _strip_comments_and_split(raw)
+    if not tokens:
+        raise ResolveError("config file is empty after parsing")
+
+    for token in tokens:
+        if mode == "endpoints":
+            if not _ENDPOINT_RE.match(token):
+                raise ResolveError(
+                    f"rejected endpoint token '{token}' "
+                    "(must be host[:port] or *.host[:port])"
+                )
+            if ":" in token:
+                port = token.rsplit(":", 1)[1]
+                if not port.isdigit() or not (1 <= int(port) <= 65535):
+                    raise ResolveError(
+                        f"rejected endpoint token '{token}' "
+                        "(port out of range 1-65535)"
+                    )
+        elif mode == "vulns":
+            if not _VULN_RE.match(token):
+                raise ResolveError(
+                    f"rejected vulnerability token '{token}' "
+                    "(not a recognised CVE/GHSA/PYSEC/OSV/PVE ID)"
+                )
+        else:
+            raise ResolveError(f"unknown mode: '{mode}'")
+
+    return tokens
+
+
+# ---------------------------------------------------------------------
+# Emit helpers
+# ---------------------------------------------------------------------
+
+def _append(path: str, text: str) -> None:
+    if not path:
+        return
+    with open(path, "a", encoding="utf-8") as fh:
+        fh.write(text)
+
+
+def write_github_output(path: str, content_key: str, result: dict) -> None:
+    if not path:
+        return
+    sep = " "
+    pairs = {
+        content_key: sep.join(result["tokens"]),
+        "count": str(result["count"]),
+        "found": "true" if result["found"] else "false",
+        "path_explicit": "true" if result["path_explicit"] else "false",
+        "host_org": result["host_org"],
+        "repo": result["repo"],
+        "ref": result["ref"],
+        "resolved_sha": result["resolved_sha"],
+        "resolved_path": result["matched_path"],
+        "matched_candidate": result["matched_candidate"],
+        "source": "config",
+    }
+    lines = []
+    for key, value in pairs.items():
+        if "\n" in value or "\r" in value:
+            raise ResolveError(f"refusing to write multi-line output '{key}'")
+        lines.append(f"{key}={value}\n")
+    _append(path, "".join(lines))
+
+
+def write_step_summary(path: str, title: str, unit: str, result: dict) -> None:
+    if not path or not title:
+        return
+    expanded = (
+        f"{result['host_org']}/{result['repo']}/"
+        f"{result['matched_path']}@{result['ref']}"
+        if result["found"] else "(none found)"
+    )
+    lines = [
+        f"### {title}",
+        "",
+        "- Source: `config`",
+        f"- Resolved: `{expanded}`",
+        f"- Commit SHA: `{result['resolved_sha'] or '(n/a)'}`",
+        f"- Matched candidate: {result['matched_candidate'] or '(none)'}",
+        f"- {unit} loaded: **{result['count']}**",
+        "",
+    ]
+    _append(path, "\n".join(lines))
+
+
+# ---------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Resolve and fetch a `config` allow-list source."
+    )
+    parser.add_argument("--config", required=True)
+    parser.add_argument("--workflow-org", required=True)
+    parser.add_argument("--family", required=True)
+    parser.add_argument("--mode", required=True, choices=["endpoints", "vulns"])
+    parser.add_argument("--token", default="")
+    parser.add_argument(
+        "--token-env",
+        default="",
+        help=(
+            "Name of an environment variable holding the token. Preferred "
+            "over --token so the secret never appears in the process "
+            "argument list. Takes precedence over --token when set."
+        ),
+    )
+    parser.add_argument("--default-repo", default=".github")
+    parser.add_argument("--default-filename", default="allow_list.txt")
+    parser.add_argument("--timeout", type=int, default=30)
+    parser.add_argument("--content-key", default="ids")
+    parser.add_argument("--github-output", default=os.environ.get("GITHUB_OUTPUT", ""))
+    parser.add_argument("--step-summary", default=os.environ.get("GITHUB_STEP_SUMMARY", ""))
+    parser.add_argument("--summary-title", default="")
+    parser.add_argument("--summary-unit", default="Entries")
+    parser.add_argument("--json-stdout", action="store_true")
+    args = parser.parse_args(argv)
+
+    token = args.token
+    if args.token_env:
+        token = os.environ.get(args.token_env, "")
+
+    try:
+        resolved = resolve(
+            args.config,
+            workflow_org=args.workflow_org,
+            family=args.family,
+            default_repo=args.default_repo,
+            default_filename=args.default_filename,
+        )
+        fetched = fetch_file(
+            host_org=resolved["host_org"],
+            repo=resolved["repo"],
+            ref=resolved["ref"],
+            candidates=resolved["candidates"],
+            token=token,
+            timeout=args.timeout,
+        )
+
+        tokens: list[str] = []
+        matched_candidate = ""
+        if fetched["found"]:
+            tokens = sanitise(fetched["content"], args.mode)
+            if fetched["matched_path"] == resolved["candidates"][0]:
+                matched_candidate = (
+                    "explicit" if resolved["path_explicit"] else "org-specific"
+                )
+            else:
+                matched_candidate = "family-default"
+        elif resolved["path_explicit"]:
+            # An explicitly-named file that is missing is always a hard
+            # error: the caller asked for that exact path. Only a miss at
+            # an auto-derived (searched) path is "soft" and left for the
+            # calling action to interpret via the found=false result.
+            raise ResolveError(
+                "config file not found at explicit path "
+                f"'{resolved['candidates'][0]}' in "
+                f"{resolved['host_org']}/{resolved['repo']}@{resolved['ref']}"
+            )
+
+        result = {
+            "found": fetched["found"],
+            "path_explicit": resolved["path_explicit"],
+            "host_org": resolved["host_org"],
+            "repo": resolved["repo"],
+            "ref": resolved["ref"],
+            "resolved_sha": fetched["resolved_sha"],
+            "matched_path": fetched["matched_path"],
+            "matched_candidate": matched_candidate,
+            "comment": resolved["comment"],
+            "tokens": tokens,
+            "count": len(tokens),
+        }
+
+        write_github_output(args.github_output, args.content_key, result)
+        write_step_summary(
+            args.step_summary, args.summary_title, args.summary_unit, result
+        )
+        if args.json_stdout:
+            print(json.dumps(result))
+        return 0
+    except ResolveError as exc:
+        print(f"config resolution error: {exc}", file=sys.stderr)
+        return 1
+    except subprocess.TimeoutExpired:
+        print("config resolution error: git operation timed out", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/resolve_config_source.py
+++ b/src/resolve_config_source.py
@@ -83,16 +83,23 @@ class ResolveError(Exception):
 # Parsing
 # ---------------------------------------------------------------------
 
+
 def split_comment(value: str) -> tuple[str, str]:
-    """Split a trailing ' #...' comment (one or more spaces before '#').
+    """Split a trailing ' #...' comment (one or more spaces/tabs before '#').
 
     Returns (spec, comment). The comment (without the leading whitespace
     and '#') is informational only and never affects resolution.
+
+    Only spaces and tabs are treated as the separator before '#': a
+    newline must NOT be consumed here, otherwise a value such as
+    'lfit@main\n# hidden' would be split into a bare spec plus a
+    'comment' and slip past the newline rejection in parse_config().
     """
-    # Match the first run of whitespace followed by '#', to end of string.
-    m = re.search(r"\s+#(.*)$", value)
+    # Match the first run of spaces/tabs followed by '#', to end of line.
+    m = re.search(r"[ \t]+#[^\r\n]*$", value)
     if m:
-        return value[: m.start()], m.group(1).strip()
+        comment = value[m.start() :].lstrip(" \t")[1:].strip()
+        return value[: m.start()], comment
     return value, ""
 
 
@@ -186,8 +193,14 @@ def resolve(
     # --- ref ---
     ref = parts["ref"] or "HEAD"
     if ref != "HEAD":
-        if ref.startswith("-") or ref.startswith("/") or ".." in ref \
-                or "@{" in ref or len(ref) > 255 or not REF_RE.match(ref):
+        if (
+            ref.startswith("-")
+            or ref.startswith("/")
+            or ".." in ref
+            or "@{" in ref
+            or len(ref) > 255
+            or not REF_RE.match(ref)
+        ):
             raise ResolveError(f"invalid git ref in config: '{ref}'")
 
     # --- subpath -> filename + directory + search candidates ---
@@ -246,6 +259,7 @@ def resolve(
 # Fetch (shallow, ref-pinned, git over HTTPS)
 # ---------------------------------------------------------------------
 
+
 def _run_git(args: list[str], timeout: int) -> subprocess.CompletedProcess:
     return subprocess.run(
         ["git", *args],
@@ -272,6 +286,7 @@ def fetch_file(
     """
     url = f"https://github.com/{host_org}/{repo}.git"
     with tempfile.TemporaryDirectory() as tmp:
+
         def git(args: list[str]) -> subprocess.CompletedProcess:
             return _run_git(["-C", tmp, *args], timeout)
 
@@ -281,39 +296,61 @@ def fetch_file(
             raise ResolveError("git remote add failed")
 
         if token:
-            # Inject auth as a config header (never on the command line or
-            # in the URL, so it cannot leak via process listings or logs).
-            basic = base64.b64encode(
-                f"x-access-token:{token}".encode()
-            ).decode()
-            cfg = git([
-                "config", "--local",
-                "http.https://github.com/.extraheader",
-                f"AUTHORIZATION: basic {basic}",
-            ])
-            if cfg.returncode != 0:
-                raise ResolveError("git auth header configuration failed")
+            # Inject auth as a git config header. We write it straight
+            # into the repo's local config file rather than via
+            # `git config <key> <value>`, because the latter would place
+            # the credential in a child process's argv (visible in
+            # process listings). Writing the file keeps the token off
+            # the command line entirely; it is also never placed in the
+            # remote URL.
+            basic = base64.b64encode(f"x-access-token:{token}".encode()).decode()
+            config_path = os.path.join(tmp, ".git", "config")
+            header_line = f"\textraheader = AUTHORIZATION: basic {basic}\n"
+            try:
+                with open(config_path, "a", encoding="utf-8") as fh:
+                    fh.write('[http "https://github.com/"]\n')
+                    fh.write(header_line)
+            except OSError as exc:
+                raise ResolveError(f"git auth header configuration failed: {exc}")
 
-        fetched = git([
-            "-c", "protocol.version=2",
-            "fetch", "-q", "--depth", "1", "origin", ref,
-        ])
+        fetched = git(
+            [
+                "-c",
+                "protocol.version=2",
+                "fetch",
+                "-q",
+                "--depth",
+                "1",
+                "origin",
+                ref,
+            ]
+        )
         if fetched.returncode != 0:
             raise ResolveError(
                 f"git fetch of '{ref}' from {host_org}/{repo} failed: "
                 f"{fetched.stderr.strip()}"
             )
 
-        rev = git(["rev-parse", "FETCH_HEAD"])
+        # Peel to the underlying commit. For an annotated tag,
+        # FETCH_HEAD can name the tag object rather than the commit it
+        # points at; '^{commit}' dereferences it so resolved_sha is
+        # always a commit SHA, consistent across branch, lightweight
+        # tag, annotated tag and commit-SHA refs.
+        rev = git(["rev-parse", "FETCH_HEAD^{commit}"])
         if rev.returncode != 0:
             raise ResolveError("could not resolve FETCH_HEAD to a commit SHA")
         resolved_sha = rev.stdout.strip()
 
         for cand in candidates:
-            exists = git(["cat-file", "-e", f"FETCH_HEAD:{cand}"])
-            if exists.returncode != 0:
+            # Use 'cat-file -t' (not '-e'): '-e' also succeeds for a
+            # tree, and 'git show <commit>:<dir>' would then print a
+            # directory listing that we'd mistake for file content.
+            # Only accept a blob, matching the local-path mode's
+            # regular-file requirement.
+            typ = git(["cat-file", "-t", f"{resolved_sha}:{cand}"])
+            if typ.returncode != 0 or typ.stdout.strip() != "blob":
                 continue
-            size = git(["cat-file", "-s", f"FETCH_HEAD:{cand}"])
+            size = git(["cat-file", "-s", f"{resolved_sha}:{cand}"])
             try:
                 if size.returncode == 0 and int(size.stdout.strip()) > MAX_FILE_BYTES:
                     raise ResolveError(
@@ -321,7 +358,7 @@ def fetch_file(
                     )
             except ValueError:
                 pass
-            shown = git(["show", f"FETCH_HEAD:{cand}"])
+            shown = git(["show", f"{resolved_sha}:{cand}"])
             if shown.returncode != 0:
                 continue
             return {
@@ -343,6 +380,7 @@ def fetch_file(
 # Sanitisation (mode-selected)
 # ---------------------------------------------------------------------
 
+
 def _strip_comments_and_split(raw: str) -> list[str]:
     text = raw.lstrip("\ufeff")
     # Remove '#' comments (full-line and trailing-after-whitespace).
@@ -355,9 +393,7 @@ def _strip_comments_and_split(raw: str) -> list[str]:
 
 _HOST_BARE = r"[A-Za-z0-9][A-Za-z0-9.-]*"
 _HOST_WILD = r"\*\.[A-Za-z0-9][A-Za-z0-9.-]*"
-_ENDPOINT_RE = re.compile(
-    rf"^(?:{_HOST_BARE}|{_HOST_WILD})(?::[0-9]{{1,5}})?$"
-)
+_ENDPOINT_RE = re.compile(rf"^(?:{_HOST_BARE}|{_HOST_WILD})(?::[0-9]{{1,5}})?$")
 
 _VULN_RE = re.compile(
     r"^(?:"
@@ -392,8 +428,7 @@ def sanitise(raw: str, mode: str) -> list[str]:
                 port = token.rsplit(":", 1)[1]
                 if not port.isdigit() or not (1 <= int(port) <= 65535):
                     raise ResolveError(
-                        f"rejected endpoint token '{token}' "
-                        "(port out of range 1-65535)"
+                        f"rejected endpoint token '{token}' (port out of range 1-65535)"
                     )
         elif mode == "vulns":
             if not _VULN_RE.match(token):
@@ -411,6 +446,7 @@ def sanitise(raw: str, mode: str) -> list[str]:
 # Emit helpers
 # ---------------------------------------------------------------------
 
+
 def _append(path: str, text: str) -> None:
     if not path:
         return
@@ -427,9 +463,9 @@ def write_github_output(path: str, content_key: str, result: dict) -> None:
         "count": str(result["count"]),
         "found": "true" if result["found"] else "false",
         "path_explicit": "true" if result["path_explicit"] else "false",
-        "host_org": result["host_org"],
-        "repo": result["repo"],
-        "ref": result["ref"],
+        "resolved_host_org": result["host_org"],
+        "resolved_repo": result["repo"],
+        "resolved_ref": result["ref"],
         "resolved_sha": result["resolved_sha"],
         "resolved_path": result["matched_path"],
         "matched_candidate": result["matched_candidate"],
@@ -449,7 +485,8 @@ def write_step_summary(path: str, title: str, unit: str, result: dict) -> None:
     expanded = (
         f"{result['host_org']}/{result['repo']}/"
         f"{result['matched_path']}@{result['ref']}"
-        if result["found"] else "(none found)"
+        if result["found"]
+        else "(none found)"
     )
     lines = [
         f"### {title}",
@@ -467,6 +504,7 @@ def write_step_summary(path: str, title: str, unit: str, result: dict) -> None:
 # ---------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------
+
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
@@ -491,7 +529,9 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--timeout", type=int, default=30)
     parser.add_argument("--content-key", default="ids")
     parser.add_argument("--github-output", default=os.environ.get("GITHUB_OUTPUT", ""))
-    parser.add_argument("--step-summary", default=os.environ.get("GITHUB_STEP_SUMMARY", ""))
+    parser.add_argument(
+        "--step-summary", default=os.environ.get("GITHUB_STEP_SUMMARY", "")
+    )
     parser.add_argument("--summary-title", default="")
     parser.add_argument("--summary-unit", default="Entries")
     parser.add_argument("--json-stdout", action="store_true")
@@ -500,6 +540,11 @@ def main(argv: list[str] | None = None) -> int:
     token = args.token
     if args.token_env:
         token = os.environ.get(args.token_env, "")
+        # Drop the secret from the environment immediately after reading
+        # it, so the git subprocesses spawned below (which inherit
+        # os.environ) do not carry the token in their environment. The
+        # credential reaches git only via the repo-local config header.
+        os.environ.pop(args.token_env, None)
 
     try:
         resolved = resolve(
@@ -565,6 +610,24 @@ def main(argv: list[str] | None = None) -> int:
         return 1
     except subprocess.TimeoutExpired:
         print("config resolution error: git operation timed out", file=sys.stderr)
+        return 1
+    except FileNotFoundError:
+        # 'git' is not installed / not on PATH.
+        print(
+            "config resolution error: the 'git' executable was not found",
+            file=sys.stderr,
+        )
+        return 1
+    except UnicodeDecodeError:
+        # A fetched blob (or git output) was not valid UTF-8.
+        print(
+            "config resolution error: fetched content is not valid UTF-8",
+            file=sys.stderr,
+        )
+        return 1
+    except OSError as exc:
+        # Any other failure spawning git or reading/writing files.
+        print(f"config resolution error: {exc}", file=sys.stderr)
         return 1
 
 

--- a/tests/test_resolve_config_source.py
+++ b/tests/test_resolve_config_source.py
@@ -13,9 +13,10 @@
 # ╚══════════════════════════════════════════════════════════════════╝
 #
 # Unit tests for resolve_config_source: parsing, resolution defaults,
-# the search-candidate chain, and the mode-selected sanitisers. These
-# tests do not touch the network; fetch_file() is exercised separately
-# by an integration smoke test in CI.
+# the search-candidate chain, the mode-selected sanitisers, and
+# fetch_file() (with git interactions stubbed via _run_git, so the
+# tests never touch the network). The resolver-tests.yaml workflow runs
+# this file.
 
 # pyright: basic, reportMissingImports=false
 
@@ -160,6 +161,19 @@ def test_newline_in_config_rejected():
         _resolve("lfit@main\nevil")
 
 
+def test_newline_disguised_as_comment_rejected():
+    # A newline before '#' must NOT be treated as a comment separator,
+    # otherwise the trailing line would slip past newline rejection.
+    with pytest.raises(rcs.ResolveError):
+        _resolve("lfit@main\n# hidden")
+
+
+def test_split_comment_ignores_newline_separator():
+    spec, comment = rcs.split_comment("lfit@main\n# hidden")
+    assert spec == "lfit@main\n# hidden"
+    assert comment == ""
+
+
 # ---------------------------------------------------------------------
 # Sanitisers
 # ---------------------------------------------------------------------
@@ -217,3 +231,180 @@ def test_sanitise_empty_after_comments_raises():
 def test_unknown_mode_raises():
     with pytest.raises(rcs.ResolveError):
         rcs.sanitise("github.com", "bogus")
+
+
+# ---------------------------------------------------------------------
+# fetch_file (git interactions stubbed via _run_git)
+# ---------------------------------------------------------------------
+
+import subprocess  # noqa: E402
+
+_FAKE_SHA = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+
+
+def _install_fake_git(
+    monkeypatch, *, fetch_rc=0, sha=_FAKE_SHA, files=None, sizes=None, trees=None
+):
+    """Stub rcs._run_git so fetch_file() runs without touching git/network.
+
+    files maps an in-repo path to its content; sizes optionally overrides
+    the reported blob size; trees is a set of paths reported as 'tree'
+    objects (directories). Returns the list of git argument vectors
+    (with the leading '-C <tmp>' stripped) for assertions.
+    """
+    files = files or {}
+    sizes = sizes or {}
+    trees = set(trees or [])
+    calls: list[list[str]] = []
+
+    def fake_run_git(args, timeout):
+        sub = list(args[2:])  # strip the leading ['-C', tmp]
+        calls.append(sub)
+
+        def cp(rc, out=""):
+            return subprocess.CompletedProcess(args, rc, out, "")
+
+        if sub[:1] == ["init"]:
+            return cp(0)
+        if sub[:2] == ["remote", "add"]:
+            return cp(0)
+        if "fetch" in sub:
+            return cp(fetch_rc)
+        if sub[:1] == ["rev-parse"]:
+            return cp(0, sha + "\n")
+        if sub[:2] == ["cat-file", "-t"]:
+            path = sub[2].split(":", 1)[1]
+            if path in trees:
+                return cp(0, "tree\n")
+            return cp(0, "blob\n") if path in files else cp(1)
+        if sub[:2] == ["cat-file", "-s"]:
+            path = sub[2].split(":", 1)[1]
+            size = sizes.get(path, len(files.get(path, "")))
+            return cp(0, f"{size}\n")
+        if sub[:1] == ["show"]:
+            path = sub[1].split(":", 1)[1]
+            return cp(0, files[path])
+        return cp(0)
+
+    monkeypatch.setattr(rcs, "_run_git", fake_run_git)
+    return calls
+
+
+def test_fetch_file_found_first_candidate(monkeypatch):
+    cands = [
+        ".github/python-audit/onap/allow_list.txt",
+        ".github/python-audit/allow_list.txt",
+    ]
+    _install_fake_git(monkeypatch, files={cands[0]: "CVE-2024-1234\n"})
+    result = rcs.fetch_file(
+        host_org="lfit",
+        repo=".github",
+        ref="main",
+        candidates=cands,
+    )
+    assert result["found"] is True
+    assert result["matched_path"] == cands[0]
+    assert result["resolved_sha"] == _FAKE_SHA
+    assert result["content"] == "CVE-2024-1234\n"
+
+
+def test_fetch_file_falls_back_to_second_candidate(monkeypatch):
+    cands = [
+        ".github/python-audit/onap/allow_list.txt",
+        ".github/python-audit/allow_list.txt",
+    ]
+    _install_fake_git(monkeypatch, files={cands[1]: "CVE-2024-1234\n"})
+    result = rcs.fetch_file(
+        host_org="lfit",
+        repo=".github",
+        ref="main",
+        candidates=cands,
+    )
+    assert result["found"] is True
+    assert result["matched_path"] == cands[1]
+
+
+def test_fetch_file_not_found(monkeypatch):
+    cands = ["a/x.txt", "b/x.txt"]
+    _install_fake_git(monkeypatch, files={})
+    result = rcs.fetch_file(
+        host_org="lfit",
+        repo=".github",
+        ref="main",
+        candidates=cands,
+    )
+    assert result["found"] is False
+    assert result["matched_path"] == ""
+    assert result["content"] is None
+    assert result["resolved_sha"] == _FAKE_SHA
+
+
+def test_fetch_file_peels_to_commit(monkeypatch):
+    cands = ["a/x.txt"]
+    calls = _install_fake_git(monkeypatch, files={"a/x.txt": "CVE-2024-1234"})
+    rcs.fetch_file(
+        host_org="lfit",
+        repo=".github",
+        ref="v1.0.0",
+        candidates=cands,
+    )
+    assert ["rev-parse", "FETCH_HEAD^{commit}"] in calls
+
+
+def test_fetch_file_fetch_failure_raises(monkeypatch):
+    _install_fake_git(monkeypatch, fetch_rc=1)
+    with pytest.raises(rcs.ResolveError):
+        rcs.fetch_file(
+            host_org="lfit",
+            repo=".github",
+            ref="main",
+            candidates=["a/x.txt"],
+        )
+
+
+def test_fetch_file_size_limit_raises(monkeypatch):
+    cands = ["a/x.txt"]
+    _install_fake_git(
+        monkeypatch,
+        files={"a/x.txt": "x"},
+        sizes={"a/x.txt": rcs.MAX_FILE_BYTES + 1},
+    )
+    with pytest.raises(rcs.ResolveError):
+        rcs.fetch_file(
+            host_org="lfit",
+            repo=".github",
+            ref="main",
+            candidates=cands,
+        )
+
+
+def test_fetch_file_skips_directory_candidate(monkeypatch):
+    # A candidate that resolves to a tree (directory) must not be read
+    # as content; the fall-through candidate (a blob) is used instead.
+    cands = ["a/dir", "b/x.txt"]
+    _install_fake_git(
+        monkeypatch,
+        files={"b/x.txt": "CVE-2024-1234\n"},
+        trees=["a/dir"],
+    )
+    result = rcs.fetch_file(
+        host_org="lfit",
+        repo=".github",
+        ref="main",
+        candidates=cands,
+    )
+    assert result["found"] is True
+    assert result["matched_path"] == "b/x.txt"
+
+
+def test_fetch_file_directory_only_not_found(monkeypatch):
+    # When the only candidate is a directory, nothing is read.
+    cands = ["a/dir"]
+    _install_fake_git(monkeypatch, trees=["a/dir"])
+    result = rcs.fetch_file(
+        host_org="lfit",
+        repo=".github",
+        ref="main",
+        candidates=cands,
+    )
+    assert result["found"] is False

--- a/tests/test_resolve_config_source.py
+++ b/tests/test_resolve_config_source.py
@@ -1,0 +1,219 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+#
+# ╔══════════════════════════════════════════════════════════════════╗
+# ║  SYNCHRONISED FILE — DO NOT EDIT IN ISOLATION                      ║
+# ║                                                                    ║
+# ║  Mirrored across:                                                  ║
+# ║    - lfreleng-actions/python-audit-action       : tests/...        ║
+# ║    - lfreleng-actions/harden-runner-block-action: tests/...        ║
+# ║                                                                    ║
+# ║  These tests pin the shared `config` grammar. Changes must land    ║
+# ║  as paired PRs in both repositories together with the module.      ║
+# ╚══════════════════════════════════════════════════════════════════╝
+#
+# Unit tests for resolve_config_source: parsing, resolution defaults,
+# the search-candidate chain, and the mode-selected sanitisers. These
+# tests do not touch the network; fetch_file() is exercised separately
+# by an integration smoke test in CI.
+
+# pyright: basic, reportMissingImports=false
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import resolve_config_source as rcs  # noqa: E402
+
+
+# ---------------------------------------------------------------------
+# Comment splitting
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value,expected_spec,expected_comment",
+    [
+        ("lfit@v1.1.0", "lfit@v1.1.0", ""),
+        ("lfit@v1.1.0 # hello", "lfit@v1.1.0", "hello"),
+        ("lfit@v1.1.0  # two spaces", "lfit@v1.1.0", "two spaces"),
+        ("lfit@v1.1.0\t# tab", "lfit@v1.1.0", "tab"),
+        ("lfit//f.txt@v1 # many words here", "lfit//f.txt@v1", "many words here"),
+    ],
+)
+def test_split_comment(value, expected_spec, expected_comment):
+    spec, comment = rcs.split_comment(value)
+    assert spec == expected_spec
+    assert comment == expected_comment
+
+
+# ---------------------------------------------------------------------
+# Resolution + search candidates
+# ---------------------------------------------------------------------
+
+
+def _resolve(spec, org="onap", family="python-audit"):
+    return rcs.resolve(spec, workflow_org=org, family=family)
+
+
+def test_org_only_default_branch():
+    r = _resolve("lfreleng-actions@main")
+    assert r["host_org"] == "lfreleng-actions"
+    assert r["repo"] == ".github"
+    assert r["ref"] == "main"
+    assert r["candidates"] == [
+        ".github/python-audit/onap/allow_list.txt",
+        ".github/python-audit/allow_list.txt",
+    ]
+    assert r["path_explicit"] is False
+
+
+def test_no_ref_defaults_to_head():
+    r = _resolve("lfit")
+    assert r["ref"] == "HEAD"
+
+
+def test_sha_ref_with_comment():
+    r = _resolve("lfit@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v1.0.0")
+    assert r["host_org"] == "lfit"
+    assert r["ref"] == "ab7a9404c0f3da075243ca237b5fac12c98deaa5"
+    assert r["comment"] == "v1.0.0"
+
+
+def test_filename_only_keeps_default_dir_search():
+    r = _resolve("lfit//custom_list.txt@v1.1.0")
+    assert r["candidates"] == [
+        ".github/python-audit/onap/custom_list.txt",
+        ".github/python-audit/custom_list.txt",
+    ]
+    assert r["path_explicit"] is False
+
+
+def test_bare_double_slash_uses_defaults():
+    r = _resolve("lfit//@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # note")
+    assert r["candidates"] == [
+        ".github/python-audit/onap/allow_list.txt",
+        ".github/python-audit/allow_list.txt",
+    ]
+    assert r["ref"] == "ab7a9404c0f3da075243ca237b5fac12c98deaa5"
+
+
+def test_explicit_directory_disables_search():
+    r = _resolve("lfit//configs/onap/list.txt@main")
+    assert r["candidates"] == ["configs/onap/list.txt"]
+    assert r["path_explicit"] is True
+
+
+def test_explicit_repo_override():
+    r = _resolve("lfit/special-repo//list.txt@main")
+    assert r["host_org"] == "lfit"
+    assert r["repo"] == "special-repo"
+
+
+def test_empty_host_org_defaults_to_workflow_org():
+    r = _resolve("//team_list.txt@main", org="onap")
+    assert r["host_org"] == "onap"
+    assert r["candidates"][0] == ".github/python-audit/onap/team_list.txt"
+
+
+def test_family_appears_in_default_path():
+    r = _resolve("lfit@main", family="harden-runner")
+    assert r["candidates"] == [
+        ".github/harden-runner/onap/allow_list.txt",
+        ".github/harden-runner/allow_list.txt",
+    ]
+
+
+# ---------------------------------------------------------------------
+# Rejections
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [
+        "",
+        "lfit@",
+        "lfit@a@b",
+        "lfit//a//b@main",
+        "lfit/repo/extra@main",
+        "bad org@main",
+        "lfit//../escape.txt@main",
+        "lfit///abs/path.txt@main",
+        "lfit//a\\b.txt@main",
+        "lfit@-badref",
+        "lfit@ref..with..dots",
+        "lfit@ref@{0}",
+        "lfit//evil;rm.txt@main",
+    ],
+)
+def test_invalid_specs_raise(spec):
+    with pytest.raises(rcs.ResolveError):
+        _resolve(spec)
+
+
+def test_newline_in_config_rejected():
+    with pytest.raises(rcs.ResolveError):
+        _resolve("lfit@main\nevil")
+
+
+# ---------------------------------------------------------------------
+# Sanitisers
+# ---------------------------------------------------------------------
+
+
+def test_sanitise_vulns_accepts_valid_ids():
+    raw = (
+        "# comment\n"
+        "GHSA-4xh5-x5gv-qwph\n"
+        "PYSEC-2025-183  # disputed\n"
+        "CVE-2024-12345\n"
+        "OSV-2023-1 PVE-2021-99\n"
+    )
+    assert rcs.sanitise(raw, "vulns") == [
+        "GHSA-4xh5-x5gv-qwph",
+        "PYSEC-2025-183",
+        "CVE-2024-12345",
+        "OSV-2023-1",
+        "PVE-2021-99",
+    ]
+
+
+@pytest.mark.parametrize(
+    "token",
+    ["evil;rm -rf /", "CVE-2024-1", "GHSA-XXXX-xxxx-xxxx", "not-an-id"],
+)
+def test_sanitise_vulns_rejects_bad_tokens(token):
+    with pytest.raises(rcs.ResolveError):
+        rcs.sanitise(token, "vulns")
+
+
+def test_sanitise_endpoints_accepts_valid():
+    raw = "github.com:443 *.githubusercontent.com:443 pypi.org # ok"
+    assert rcs.sanitise(raw, "endpoints") == [
+        "github.com:443",
+        "*.githubusercontent.com:443",
+        "pypi.org",
+    ]
+
+
+@pytest.mark.parametrize(
+    "token",
+    ["evil.com:0", "evil.com:99999", "*", "*:443", "ev|l.com", "a b;c"],
+)
+def test_sanitise_endpoints_rejects_bad(token):
+    with pytest.raises(rcs.ResolveError):
+        rcs.sanitise(token, "endpoints")
+
+
+def test_sanitise_empty_after_comments_raises():
+    with pytest.raises(rcs.ResolveError):
+        rcs.sanitise("# only a comment\n\n", "vulns")
+
+
+def test_unknown_mode_raises():
+    with pytest.raises(rcs.ResolveError):
+        rcs.sanitise("github.com", "bogus")


### PR DESCRIPTION
## Summary

Adds centrally-managed and git-pinnable vulnerability allow-lists to
`python-audit-action`, mirroring the design of
[`lfreleng-actions/harden-runner-block-action`](https://github.com/lfreleng-actions/harden-runner-block-action/pull/9).
IDs sourced from the allow-list are de-duplicated and merged with the
existing `ignore_vulns` input; both feed `pip-audit`'s `--ignore-vuln`
list. The central file consumed by the default URL is already deployed
under `lfreleng-actions/.github` (lfreleng-actions/.github#29).

## Commits in this PR

| Commit | Purpose |
| --- | --- |
| `Feat: Support central vulnerability allow-list file` | The `allow_list_path`/`url`/`org`/`disable` inputs, the default-URL fetch from the org's `.github` repo, and the merge-with-`ignore_vulns` step. |
| `Feat: Add git-pinnable config allow-list source` | The `config` + `token` inputs, the shared `src/resolve_config_source.py` resolver, the resolve/merge wiring, new `resolved_*` outputs, and the synced `tests/` suite. |
| `CI: Add shared resolver drift check` | `sync-shared-resolver.yaml` — fails if the mirrored resolver/tests diverge from `harden-runner-block-action`. |
| `Feat: Add allow_list_summary toggle to curb matrix bloat` | `allow_list_summary` input to suppress the per-leg step-summary block on matrix jobs. |
| `Fix: Address Copilot review feedback` | All review-cycle fixes (see below), plus `resolver-tests.yaml` (pytest CI) and `pytest` added to the mypy hook. |

## Inputs added

`allow_list_path`, `allow_list_url`, `allow_list_org`,
`allow_list_disable`, `config`, `token`, `allow_list_summary`.

Legacy precedence: `allow_list_path` > `allow_list_url` > default URL
from `allow_list_org`
(`https://raw.githubusercontent.com/<org>/.github/HEAD/.github/python-audit/<org>/allow_list.txt`).

## `config` (git, SHA-pinnable)

A `uses:`-style coordinate
(`<host-org>[/<repo>][//<subpath>][@<ref>][ # comment]`) fetched with a
shallow, ref-pinned **git** fetch (branch, tag or commit SHA). Mutually
exclusive with the `allow_list_path`/`url`/`org`/`disable` source inputs
(`allow_list_summary` still applies). The resolver is a stdlib-only
Python module mirrored byte-for-byte with `harden-runner-block-action`
and exercised by a `pytest` CI job; `resolved_sha` always reports the
exact (peeled) commit. Private host repos authenticate via `token`,
written to the temp repo's git config (never on argv) and masked.

## Soft-fail semantics

A missing **central** file is not an error: when the default URL returns
**HTTP 404** the action proceeds with `ignore_vulns` alone and emits no
warning. Transport failures (DNS/TLS/timeout/`--max-filesize`) and any
other HTTP status are hard errors. An explicitly-supplied
`allow_list_path`, `allow_list_url`, or `config` path that fails to load
is also a hard error.

## Sanitisation

Every token is matched against a strict regex of vulnerability ID
shapes — `CVE-YYYY-N{4,}`, `GHSA-xxxx-xxxx-xxxx`, `PYSEC-YYYY-N+`,
`OSV-YYYY-N+`, `PVE-N+`/`PVE-N+-N+` — identical across the `config` and
legacy load paths. Non-conforming content fails the step.

## Review-cycle hardening (in the Fix commit)

Resolver output-name alignment; `FETCH_HEAD^{commit}` SHA peeling;
blob-only candidate reads; token kept out of child env; whole-value
bash newline checks (not line-by-line grep); explicit 1–39 org-length
limit; `curl -- <url>` end-of-options marker; 404-only soft-fail; clean
`OSError`/`UnicodeDecodeError` handling; the `${{ strategy }}` example
removed from the input description (it broke action loading); docs and
mutual-exclusion message accuracy; `pytest` added to the mypy hook.

## Validation

- 52 resolver unit tests pass; `resolver-tests.yaml` runs them in CI;
  the action's own `testing.yaml` jobs pass after the action-loading fix.
- Full `pre-commit` clean (yamllint, ruff, ruff-format, mypy, write-good,
  markdownlint, reuse, codespell, Validate GitHub Actions).
- Commits PGP-signed with DCO + co-author trailers.

## Linked / sequencing

- Paired PR: lfreleng-actions/harden-runner-block-action#9
- Central file: lfreleng-actions/.github#29 (merged)
- Follow-up after release: drop the baked-in `ignore_vulns` default
  (`GHSA-4xh5-x5gv-qwph`) once the central file covers it; and add a
  composite-action-level `config` integration test (needs a built sample
  project + uploaded wheel artifact).