### PR TITLE
Fix: resolve Zizmor template-injection findings

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -181,14 +181,17 @@ runs:
 
     - name: 'Install build products/dependencies'
       shell: bash
+      env:
+        INPUT_PATH_PREFIX: ${{ inputs.path_prefix }}
+        INPUT_ARTEFACT_PATH: ${{ inputs.artefact_path }}
       run: |
         # Install build products/dependencies
-        path_prefix="${{ inputs.path_prefix }}"
+        path_prefix="$INPUT_PATH_PREFIX"
         echo 'Upgrading: pip, setuptools'
         python -m pip install --disable-pip-version-check \
           -q --upgrade pip setuptools
         echo 'Installing built package(s) and dependencies'
-        for wheel in ${{ inputs.artefact_path }}/*.whl; do
+        for wheel in "$INPUT_ARTEFACT_PATH"/*.whl; do
                 pip install -q "$wheel"
         done
         # Check for requirements.txt in path_prefix if provided


### PR DESCRIPTION
## Pull request overview

Zizmor's regular-persona audit (the configuration used by the
organisation-level scheduled scan) reported `template-injection`
findings in this composite action. This change resolves them, bringing
the action to zero medium-or-higher findings.

### Changes

- **template-injection:** the "Install build products/dependencies"
  step interpolated `${{ inputs.path_prefix }}` and
  `${{ inputs.artefact_path }}` directly into the bash `run` block.
  Both are now routed through a per-step `env:` block
  (`INPUT_PATH_PREFIX`, `INPUT_ARTEFACT_PATH`). `path_prefix` is
  referenced as a quoted shell variable; the artefact path is quoted
  while leaving the trailing `/*.whl` glob unquoted so wheel discovery
  still works.

### Impact

No behavioural change.
