### PR TITLE
Chore: Pin ruff rule selection

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+# Pin the ruff rule set explicitly.
+#
+# Without a `select`, ruff applies its *default* rule set, and that
+# default is not stable across releases:
+#
+#     ruff 0.15.22 ->  59 rules across  2 categories (E, F)
+#     ruff 0.16.0  -> 413 rules across 38 categories
+#
+# A routine pre-commit autoupdate crossing that boundary changed which
+# rules run and broke repositories across this organisation, on code
+# nobody had touched.
+#
+# The selection below is deliberately narrow: it is the widest set this
+# repository already satisfies, so pinning changes no behaviour today.
+# It is a subset of the organisation superset
+# ("E", "W", "F", "I", "B", "C4", "UP"), short by "I" and "B".  Adopting
+# those two is worthwhile but is a code change, not a configuration one:
+#
+#   - "B" adds one B904 (raise-without-from) site in
+#     src/resolve_config_source.py, which needs a judgement about which
+#     exception context to preserve.
+#   - "I" flags the import block in the test modules, which deliberately
+#     call sys.path.insert() before importing the module under test.
+#     One of those files is mirrored byte-for-byte with a sibling
+#     repository and is marked "DO NOT EDIT IN ISOLATION", so touching
+#     it requires paired pull requests in both repositories.
+#
+# Both belong in their own reviewed change rather than riding along with
+# a version bump.
+#
+# Note that this pins the rule set at CATEGORY level, not rule level.
+# Ruff selectors are prefixes, so a future release adding new E* or F*
+# rules would enable them here automatically.  Pinning every rule code
+# individually would be exhaustive and unmaintainable; the aim is to
+# bound the blast radius, reducing "413 rules across 38 categories"
+# back to five, not to freeze the set outright.
+#
+# `line-length` and `target-version` are intentionally left unset so
+# ruff's own defaults continue to apply unchanged.
+
+[lint]
+select = ["E", "W", "F", "C4", "UP"]
+
+ignore = [
+  "E501", # line-too-long: the formatter owns line length
+  "B008", # function call in argument default: typer/click idiom
+]
+
+[lint.per-file-ignores]
+# Test suites legitimately break rules that matter in library code.
+#
+# None of these codes is reachable under the current `select`.  They are
+# listed anyway so that a later widening, to "S", "ARG" or "PL", does not
+# immediately flag every test module.  PLR0917 is the concrete case
+# already seen elsewhere in this organisation: tests stacking @patch
+# decorators cannot satisfy it, because unittest.mock injects its mocks
+# positionally, so a keyword-only signature is impossible rather than
+# merely inconvenient.
+"tests/**/*.py" = ["S101", "ARG", "PLR0913", "PLR0917", "PLR2004"]


### PR DESCRIPTION
## Why

This repository runs the ruff hook with **no ruff configuration**, so it applies whatever ruff's *default* rule set happens to be. That default is not stable across releases:

```
ruff 0.15.22 ->  59 rules across  2 categories (E, F)
ruff 0.16.0  -> 413 rules across 38 categories
```

A routine `pre-commit autoupdate` crossing that boundary changes which rules run on code nobody has touched. That is exactly what fails the open autoupdate PR #173 here, on six findings:

| Rule | Count | Location |
| ---- | ----- | -------- |
| `RUF100` | 2 | `tests/test_resolve_config_source.py` |
| `I001` | 1 | `tests/test_resolve_config_source.py` |
| `SIM102` | 1 | `src/resolve_config_source.py` |
| `PIE810` | 1 | `src/resolve_config_source.py` |
| `PLW1510` | 1 | `src/resolve_config_source.py` |

## Deliberately narrow

`select = ["E", "W", "F", "C4", "UP"]` is the **widest set this repository already satisfies**, so pinning changes no behaviour today.

It falls short of the organisation superset (`E, W, F, I, B, C4, UP`) by **`I`** and **`B`**. I checked both, and each is a *code* change rather than a configuration one:

- **`B`** adds one `B904` raise-without-from site at `src/resolve_config_source.py:314`, which needs a judgement about which exception context to preserve.
- **`I`** flags the import block in `tests/test_resolve_config_source.py`, which deliberately calls `sys.path.insert()` *before* importing the module under test. The autofix is only a blank-line removal, but that file is **mirrored byte-for-byte with `harden-runner-block-action`** and carries an explicit banner:

  > ╔══ SYNCHRONISED FILE — DO NOT EDIT IN ISOLATION ══╗
  > Changes must land as paired PRs in both repositories together with the module.

  So it cannot be resolved from this repository alone, and I have deliberately not touched it.

Folding either into a configuration chore would obscure both.

A nice side effect of selecting `E`: the existing `# noqa: E402` on line 30 becomes meaningful again. It is currently *unused* (hence the two `RUF100` findings), because `E402` is not enabled under ruff's default.

## Note on category-level pinning

Ruff selectors are prefixes, so a future release adding new `E*` or `F*` rules will still enable them here. Pinning every rule code individually would be exhaustive and unmaintainable; the aim is to bound the blast radius — 38 categories back to five — not to freeze the set outright.

`line-length` and `target-version` are left unset on purpose. Both would change existing behaviour rather than pin it (`target-version` alters which `pyupgrade` rules fire).

## Validation

- `ruff 0.16.0 check src tests` → **All checks passed!**
- `ruff 0.15.22 check src tests` → **All checks passed!** (so this is not a one-way door)
- `pre-commit run --all-files` → every hook passes, including `reuse lint` on the new file
- No code changes accompany this — configuration only

Unblocks #173.

## Related

Paired with the identical change in `harden-runner-block-action`, which shares the same `resolve_config_source` module and test file.
