### PR TITLE
CI: Clarify shared resolver drift reporting

### DIFF
--- a/.github/workflows/sync-shared-resolver.yaml
+++ b/.github/workflows/sync-shared-resolver.yaml
@@ -17,6 +17,20 @@
 # briefly makes the two default branches differ until the second one
 # merges) does not deadlock. A red main after the first merge is the
 # intended signal to land the paired PR in the sibling repo.
+#
+# The three possible outcomes are reported distinctly — in the console
+# log, the job summary and the annotations — so a red run is never
+# ambiguous about whether the check measured something or simply could
+# not run:
+#
+#   exit 0  ✅ every shared file is byte-identical with the sibling
+#   exit 1  ❌ the comparison ran and found drift (the measured signal)
+#   exit 2  ⚠️ at least one file could not be compared, so the check
+#              is inconclusive for it; a transport or tooling failure
+#              that is evidence of neither drift nor sync
+#
+# Drift takes precedence over an inconclusive file: a confirmed
+# difference is actionable, so it decides the exit code.
 
 name: 'Sync shared resolver 🔁'
 
@@ -64,31 +78,163 @@ jobs:
       - name: "Diff shared files against ${{ env.SIBLING_REPO }}"
         shell: bash
         run: |
-          # Compare each shared file against the sibling repo's default
-          # branch (HEAD). Any difference fails the job.
+          # Compare each shared file against the sibling repository's
+          # default branch (HEAD), separating the two very different
+          # reasons this job can go red:
+          #
+          #   drift    the comparison ran and the files differ. This is
+          #            the condition the job exists to measure, and is
+          #            expected (briefly) between paired PRs landing.
+          #   not run  the sibling copy could not be fetched, or diff
+          #            itself failed, so no verdict was reached for
+          #            that file.
           set -euo pipefail
-          fail=0
+
           files=(
             'src/resolve_config_source.py'
             'tests/test_resolve_config_source.py'
           )
+
+          sibling_url="https://github.com/${SIBLING_REPO}"
+          sibling="${RUNNER_TEMP}/sibling.tmp"
+          filediff="${RUNNER_TEMP}/file-diff.txt"
+          details="${RUNNER_TEMP}/drift-details.md"
+          : > "${details}"
+
+          matched=()
+          drifted=()
+          blocked=()
+
+          {
+            echo "## Shared resolver sync 🔁"
+            echo
+            echo "Comparing the mirrored resolver files in this"
+            echo "repository against the default branch of"
+            echo "[\`${SIBLING_REPO}\`](${sibling_url})."
+            echo
+            echo "| Shared file | Result |"
+            echo "| --- | --- |"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
           for f in "${files[@]}"; do
             url="https://raw.githubusercontent.com/${SIBLING_REPO}/HEAD/${f}"
             echo "Fetching ${url}"
             if ! curl --proto '=https' --tlsv1.2 \
-              -sSfL --max-time 30 -o sibling.tmp "$url"; then
-              echo "::error::Could not fetch ${f} from ${SIBLING_REPO}"
-              fail=1
+              -sSfL --max-time 30 -o "${sibling}" "${url}"; then
+              blocked+=("${f}")
+              echo "⚠️ Comparison could not be performed for ${f}"
+              echo "::error title=Sync check could not run::Could not" \
+                "fetch ${f} from ${SIBLING_REPO}; no verdict was" \
+                "reached for this file. This is a transport failure," \
+                "not resolver drift. Re-run this job."
+              echo "| \`${f}\` | ⚠️ Not compared (fetch failed) |" \
+                >> "${GITHUB_STEP_SUMMARY}"
+              rm -f "${sibling}" "${filediff}"
               continue
             fi
-            if diff -u "$f" sibling.tmp; then
-              echo "${f} matches ${SIBLING_REPO} ✅"
+            # diff exits 0 for identical, 1 for differing and 2+ for
+            # its own failures; only 1 is evidence of drift.
+            rc=0
+            diff -u --label "${f} (this repository)" \
+              --label "${f} (${SIBLING_REPO})" \
+              "${f}" "${sibling}" > "${filediff}" || rc=$?
+            if [ "${rc}" -eq 0 ]; then
+              matched+=("${f}")
+              echo "✅ Comparison performed successfully"
+              echo "✅ No drift: ${f} matches ${SIBLING_REPO}"
+              echo "| \`${f}\` | ✅ In sync |" \
+                >> "${GITHUB_STEP_SUMMARY}"
+            elif [ "${rc}" -eq 1 ]; then
+              drifted+=("${f}")
+              cat "${filediff}"
+              echo "✅ Comparison performed successfully"
+              echo "❌ Configuration drift detected in ${f}"
+              echo "::error title=Shared resolver drift::${f} differs" \
+                "from ${SIBLING_REPO}; the shared resolver must stay" \
+                "byte-identical. Raise paired PRs in both repositories."
+              echo "| \`${f}\` | ❌ Drift detected |" \
+                >> "${GITHUB_STEP_SUMMARY}"
+              {
+                echo
+                echo "<details>"
+                echo "<summary>Diff: <code>${f}</code></summary>"
+                echo
+                echo '```diff'
+                cat "${filediff}"
+                echo '```'
+                echo
+                echo "</details>"
+              } >> "${details}"
             else
-              echo "::error::${f} differs from ${SIBLING_REPO};" \
-                   "the shared resolver must stay byte-identical." \
-                   "Raise paired PRs in both repositories."
-              fail=1
+              blocked+=("${f}")
+              cat "${filediff}"
+              echo "⚠️ Comparison could not be performed for ${f}"
+              echo "::error title=Sync check could not run::diff exited" \
+                "${rc} while comparing ${f}; no verdict was reached for" \
+                "this file. This is a tooling failure, not resolver" \
+                "drift. Re-run this job."
+              echo "| \`${f}\` | ⚠️ Not compared (diff error ${rc}) |" \
+                >> "${GITHUB_STEP_SUMMARY}"
             fi
-            rm -f sibling.tmp
+            rm -f "${sibling}" "${filediff}"
           done
-          exit "$fail"
+
+          cat "${details}" >> "${GITHUB_STEP_SUMMARY}"
+          rm -f "${details}"
+
+          echo
+          echo "Shared files checked against ${SIBLING_REPO}:"
+          echo "  ✅ in sync ....... ${#matched[@]}"
+          echo "  ❌ drifted ....... ${#drifted[@]}"
+          echo "  ⚠️ not compared .. ${#blocked[@]}"
+          echo
+
+          if [ "${#drifted[@]}" -gt 0 ]; then
+            {
+              echo
+              echo "### ❌ Configuration drift detected"
+              echo
+              echo "The comparison ran successfully and found that the"
+              echo "shared resolver has diverged. It must stay"
+              echo "byte-identical in both repositories, so changes are"
+              echo "raised as **paired pull requests**."
+              echo
+              echo "If the paired PR has already merged in"
+              echo "[\`${SIBLING_REPO}\`](${sibling_url}), land the"
+              echo "matching PR here; this job returns green on the"
+              echo "next push to \`main\`."
+            } >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
+          if [ "${#blocked[@]}" -gt 0 ]; then
+            {
+              echo
+              echo "### ⚠️ Check incomplete"
+              echo
+              echo "${#blocked[@]} of ${#files[@]} shared file(s) could"
+              echo "not be compared, so the check reached **no verdict**"
+              echo "for them. This is a transport or tooling failure and"
+              echo "is evidence of neither drift nor sync for the"
+              echo "affected files. Re-run this job."
+            } >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
+          if [ "${#drifted[@]}" -gt 0 ]; then
+            echo "❌ FAILED: configuration drift detected (see summary)"
+            exit 1
+          fi
+
+          if [ "${#blocked[@]}" -gt 0 ]; then
+            echo "⚠️ FAILED: check incomplete, no verdict for" \
+              "${#blocked[@]} of ${#files[@]} file(s) (see summary)"
+            exit 2
+          fi
+
+          {
+            echo
+            echo "### ✅ No drift detected"
+            echo
+            echo "Every shared file is byte-identical with"
+            echo "\`${SIBLING_REPO}\`."
+          } >> "${GITHUB_STEP_SUMMARY}"
+          echo "✅ PASSED: all shared files match ${SIBLING_REPO}"


### PR DESCRIPTION
## Problem

The scheduled run on 2026-08-03 ([run 30793145483](https://github.com/lfreleng-actions/python-audit-action/actions/runs/30793145483)) correctly caught the window where the `sole-org fallback` paired PRs had landed in `harden-runner-block-action` but not yet here. The reporting, however, made that hard to tell:

- no `GITHUB_STEP_SUMMARY` output at all, only three untitled `::error::` annotations;
- a failed `curl` and a genuine byte-difference produced the same annotation shape and the same exit code, so a transport outage was indistinguishable from the drift the job exists to measure — or from a plain workflow syntax error;
- the console log ended with a raw diff tail followed immediately by `Error:` lines, with no marker saying whether the comparison had actually completed.

## Change

Outcomes are now separated and labelled everywhere they surface:

| Outcome | Exit | Annotation title |
| --- | --- | --- |
| ✅ All shared files byte-identical | 0 | — |
| ❌ Comparison ran, files differ | 1 | `Shared resolver drift` |
| ⚠️ Sibling file unfetchable, nothing compared | 2 | `Sync check could not run` |

Also:

- each file logs `✅ Comparison performed successfully` followed by an explicit per-file verdict, so a diff tail is never the last thing before `Error:`;
- `diff --label` names both sides (`… (this repository)` / `… (lfreleng-actions/harden-runner-block-action)`) instead of leaking `sibling.tmp`;
- a step summary is written with a per-file result table, collapsible diffs, and the next action to take — including the note that landing the paired PR turns this green on the next push to `main`;
- a per-outcome counter block precedes the verdict;
- temp files move to `${RUNNER_TEMP}` rather than the checkout.

The "could not run" case explicitly states that it is evidence of neither drift nor sync, which is the distinction that was missing.

## Paired change

An identical change (differing only in `SIBLING_REPO`) is raised in the sibling repository so both sides report consistently. The mirrored `src/resolve_config_source.py` and `tests/test_resolve_config_source.py` are untouched, so the two PRs are independent and neither can deadlock the other.

## Validation

- `pre-commit run --files .github/workflows/sync-shared-resolver.yaml` — passes (yamllint, actionlint incl. shellcheck, check-github-workflows).
- All three outcomes exercised locally against a stubbed `curl` (in-sync, drift, fetch failure), confirming exit codes 0/1/2 and the rendered summary in each case.
- This workflow triggers on pushes touching itself, so the in-sync path is exercised on merge.
